### PR TITLE
Fixed 2 bugs in ARM.ps1 and Artifactory.ps1

### DIFF
--- a/PSDeploy/PSDeployScripts/ARM.ps1
+++ b/PSDeploy/PSDeployScripts/ARM.ps1
@@ -1,5 +1,4 @@
-﻿#Requires -module AzureRM.Resources
-<#
+﻿<#
     .SYNOPSIS
         Deploy using Azure Resource Manager cmdlets.
 
@@ -11,6 +10,7 @@
     .PARAMETER Deployment
         Deployment to run
 #>
+#Requires -modules AzureRM.Resources
 [cmdletbinding()]
 param (
     [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]

--- a/PSDeploy/PSDeployScripts/Artifactory.ps1
+++ b/PSDeploy/PSDeployScripts/Artifactory.ps1
@@ -170,6 +170,6 @@ foreach($Deploy in $Deployment) {
         }
     }
     else {
-        throw "Unable to find [$(Deploy.Source)]"
+        throw "Unable to find [$($Deploy.Source)]"
     }
 }


### PR DESCRIPTION
- ARM.ps1 - Comment Based help was broken by the #Requires Statement at the beginning of the Script. Moved it below Help. 
- Artifactory.ps1 - Missing a $ in the Throw statement. Wouldn't properly Throw the message.
