### PR TITLE
Fix #41: use ProviderPath instead of Path with Resolve-Path 

### DIFF
--- a/PSDeploy/Public/Get-PSDeployment.ps1
+++ b/PSDeploy/Public/Get-PSDeployment.ps1
@@ -222,7 +222,7 @@
                     #Determine the path to this source. Try absolute, fall back on relative
                     if(Test-Path $Source -ErrorAction SilentlyContinue)
                     {
-                        $LocalSource = ( Resolve-Path $Source ).Path
+                        $LocalSource = ( Resolve-Path $Source ).ProviderPath
                     }
                     else
                     {

--- a/PSDeploy/Public/Get-PSDeployment.ps1
+++ b/PSDeploy/Public/Get-PSDeployment.ps1
@@ -162,7 +162,7 @@
                     #Fail silently if not file/folder...
                     if(Test-Path $Source -ErrorAction SilentlyContinue)
                     {
-                        $LocalSource = ( Resolve-Path $Source ).Path
+                        $LocalSource = ( Resolve-Path $Source ).ProviderPath
                     }
                     else
                     {


### PR DESCRIPTION
Resolve ProviderPath to handle PSDrive and UNC
