### PR TITLE
fix: non existing $headers during artifactory deploy

### DIFF
--- a/PSDeploy/PSDeployScripts/Artifactory.ps1
+++ b/PSDeploy/PSDeployScripts/Artifactory.ps1
@@ -130,6 +130,7 @@ foreach($Deploy in $Deployment) {
                 }
             }
 
+            $headers = @{}
             if ($Checksum) {
                 # Calculate hash of source file and set in headers
                 Write-Verbose -Message "Calculating checksums"
@@ -154,7 +155,7 @@ foreach($Deploy in $Deployment) {
             }
 
             if ($PSBoundParameters.Contains('ApiKey')) {
-                $headers."X-JFrog-Art-Api"=$ApiKey
+                $headers."X-JFrog-Art-Api" = $ApiKey
             }
             
             Write-Verbose -Message "Deploying [$($Deploy.Source)] to [$url]"


### PR DESCRIPTION
When $checksum is false and either $deployArchive is true or $ApiKey is true the $headers variable does not exist and the deployment fails with an exception.

The property 'X-JFrog-Art-Api' cannot be found on this object. Verify that the property exists and can be set.
At C:\Program Files\WindowsPowerShell\Modules\PSDeploy\0.1.14\PSDeployScripts\Artifactory.ps1:154 char:17
-                 $headers."X-JFrog-Art-Api" = $ApiKey
-                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  - CategoryInfo          : InvalidOperation: (:) [], RuntimeException
  - FullyQualifiedErrorId : PropertyNotFound
