### PR TITLE
Added Git deployment

### DIFF
--- a/PSDeploy/PSDeploy.yml
+++ b/PSDeploy/PSDeploy.yml
@@ -38,3 +38,7 @@ PSGalleryModule:
 Task:
   Script: Task.ps1
   Description: Support deployments by handling simple tasks.
+
+Git:
+  Script: Git.ps1
+  Description: Uses git with a simple workflow to commit and push any modification in a repository.

--- a/PSDeploy/PSDeployScripts/Git.ps1
+++ b/PSDeploy/PSDeployScripts/Git.ps1
@@ -10,6 +10,9 @@
 
     .PARAMETER CommitMessage
         Message added to each commit
+
+    .PARAMETER Tag
+        Tag added to the commit
 #>
 [cmdletbinding()]
 param(
@@ -17,7 +20,9 @@ param(
     [psobject[]]$Deployment,
 
     [Parameter(Mandatory)]
-    [string]$CommitMessage
+    [string]$CommitMessage,
+
+    [string]$Tag
 )
 
 foreach($deploy in $Deployment) {
@@ -52,6 +57,17 @@ foreach($deploy in $Deployment) {
             # Push the modifications 
             Write-Verbose "Invoking git push origin $target"
             git push origin $target
+
+            if ($PSBoundParameters.ContainsKey('Tag')) {
+                # Create the tag locally 
+                Write-Verbose "git tag $Tag"
+                git tag $Tag
+
+                # Push the tag on the remote repository
+                Write-Verbose "git push origin $Tag"
+                git push origin $Tag
+
+            }
         } Else {
             throw $status
         }

--- a/PSDeploy/PSDeployScripts/Git.ps1
+++ b/PSDeploy/PSDeployScripts/Git.ps1
@@ -1,0 +1,62 @@
+<#
+    .SYNOPSIS
+        Deploys / Push to a Git repository.
+
+    .DESCRIPTION
+        Deploys / Push to a Git repository.
+
+    .PARAMETER Deployment
+        Deployment to run
+
+    .PARAMETER CommitMessage
+        Message added to each commit
+#>
+[cmdletbinding()]
+param(
+    [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [psobject[]]$Deployment,
+
+    [Parameter(Mandatory)]
+    [string]$CommitMessage
+)
+
+foreach($deploy in $Deployment) {
+    foreach($target in $deploy.Targets) {
+
+        Write-Verbose -Message "Starting deployment [$($deploy.DeploymentName)] to branch [$Target]"
+
+        # Store current path
+        $CurrentPath = (Get-Item -Path ".\" -Verbose).FullName
+
+        Write-Verbose "Invoking cd $($deploy.Source)"
+        cd $deploy.Source
+
+        # Get git status
+        $status = git status
+
+        # If git status doesn't throw an error, continue the deployment. 
+        If ($lastExitCode -eq 0) {
+
+            # Checkout to the branch specified in $target
+            Write-Verbose "Invoking git checkout $target"
+            git checkout $target
+
+            # add all new / modified files to the git index
+            Write-Verbose "Invoking git add *"
+            git add *
+
+            # Commit the git index with a message specified in the parameter CommitMessage
+            Write-Verbose "Invoking git commit -m `"$($deploy.DeploymentOptions.CommitMessage)`""
+            git commit -m "$($deploy.DeploymentOptions.CommitMessage)"
+
+            # Push the modifications 
+            Write-Verbose "Invoking git push origin $target"
+            git push origin $target
+        } Else {
+            throw $status
+        }
+
+        #Go back to the current path
+        cd $CurrentPath
+    }
+}

--- a/Tests/artifacts/DeploymentsGit.psdeploy.ps1
+++ b/Tests/artifacts/DeploymentsGit.psdeploy.ps1
@@ -1,0 +1,9 @@
+Deploy Git {
+    By GitModule Git {
+        FromSource 'D:\GitHub\PSDummy'
+        To 'Master'
+        WithOptions @{
+            CommitMessage = 'Automatically commited by PSDeploy'
+        }
+    }
+}

--- a/Tests/artifacts/DeploymentsGit.psdeploy.ps1
+++ b/Tests/artifacts/DeploymentsGit.psdeploy.ps1
@@ -2,8 +2,10 @@ Deploy Git {
     By GitModule Git {
         FromSource 'D:\GitHub\PSDummy'
         To 'Master'
+        Tagged 'Prod'
         WithOptions @{
             CommitMessage = 'Automatically commited by PSDeploy'
+            Tag = 'v1.0.0'
         }
     }
 }


### PR DESCRIPTION
This PR adds a new deployment type `Git`. The git workflow is quiet simple and can be decomposed in a few steps:
- git add 
- git commit
- git push

This PR can be seen as a RFC to see if there is any interest in this kind of deployment and also to discuss about git workflows that may differ between users.

This deployment type requires that the git command is installed and available in the PATH.

``` Powershell
Deploy Git {
    By Git Git {
        FromSource 'F:\hubic\Code\GitHub\PSDummy'
        To 'master'
        WithOptions @{
            CommitMessage = 'Automatically commited by PSDeploy'
        }
    }
}
```

`FromSource` is the local repository
`To` is the branch name
Option `CommitMessage` is the message added to each commit 
