### PR TITLE
Add Invoke-Robocopy Wrapper

### DIFF
--- a/PSDeploy/PSDeployScripts/FileSystem.ps1
+++ b/PSDeploy/PSDeployScripts/FileSystem.ps1
@@ -43,7 +43,7 @@ foreach($Map in $Deployment)
                 $Target = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Target)
 
                 Write-Verbose "Invoking ROBOCOPY.exe $($Map.Source) $Target $Arguments"
-                ROBOCOPY.exe $Map.Source $Target @Arguments
+                Invoke-Robocopy -Path $Map.Source -Destination $Target -ArgumentList $Arguments
             }
             else
             {

--- a/PSDeploy/PSDeployScripts/FilesystemRemote.ps1
+++ b/PSDeploy/PSDeployScripts/FilesystemRemote.ps1
@@ -108,7 +108,7 @@ Invoke-Command @PSBoundParameters -ScriptBlock {
                     $Target = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Target)
 
                     Write-Verbose "Invoking ROBOCOPY.exe $RemoteSource $Target $Arguments"
-                    ROBOCOPY.exe $RemoteSource $Target @Arguments
+                    Invoke-Robocopy -Path $RemoteSource -Destination $Target -ArgumentList $Arguments
                 }
                 else
                 {

--- a/PSDeploy/Private/Invoke-Robocopy.ps1
+++ b/PSDeploy/Private/Invoke-Robocopy.ps1
@@ -11,21 +11,37 @@ function Invoke-Robocopy () {
         $Destination,
 
         # List of arguments to be splatted to ROBOCOPY
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$false)]
         [array]
-        $ArgumentList
+        $ArgumentList,
+        
+        # Exit function if robocode throws "terminating" error code
+        [Parameter(Mandatory=$false)]
+        [switch]
+        $EnableExit
     )
+
+    # Remove trailing backslash
+    $Path = $Path -replace '\\$'
+    $Destination = $Destination -replace '\\$'
 
     ROBOCOPY.exe $Path $Destination @ArgumentList
 
     switch ($LastExitCode) {
         0   { Write-Output 'No files copied. Source and destination are in sync' }
         1   { Write-Output 'Files were copied successfully'}
-        2   { Write-Output 'Extra files/directories detected. Housekeeping may be required.'}
-        4   { Write-Output 'Mismatched files/directories detected. Housekeeping may be required.'}
-        8   { Write-Error 'Some files/directories could not be copied'}
-        10  { Write-Error 'Usage error or an error due to insufficient access privileges'}
+        2   { Write-Warning 'Extra files/directories detected. Housekeeping may be required.'}
+        4   { Write-Warning 'Mismatched files/directories detected. Housekeeping may be required.'}
+        8   { $RCError = 'Some files/directories could not be copied'}
+        10  { $RCError = 'Usage error or an error due to insufficient access privileges'}
+        16  { $RCError = 'No destination directory specified'}
     }
 
-    exit ($LastExitCode -band 24)
+    if ($LastExitCode -gt 4) {
+        if ($EnableExit) {
+            $host.SetShouldExit($LastExitCode)
+        } else {
+            Write-Error $RCError
+        }
+    }
 }

--- a/PSDeploy/Private/Invoke-Robocopy.ps1
+++ b/PSDeploy/Private/Invoke-Robocopy.ps1
@@ -1,0 +1,31 @@
+function Invoke-Robocopy () {
+    [cmdletbinding()]
+    param (
+        # Copy from location
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Path,
+
+        # Copy to location
+        [Parameter(Mandatory=$true)]
+        $Destination,
+
+        # List of arguments to be splatted to ROBOCOPY
+        [Parameter(Mandatory=$true)]
+        [array]
+        $ArgumentList
+    )
+
+    ROBOCOPY.exe $Path $Destination @ArgumentList
+
+    switch ($LastExitCode) {
+        0   { Write-Output 'No files copied. Source and destination are in sync' }
+        1   { Write-Output 'Files were copied successfully'}
+        2   { Write-Output 'Extra files/directories detected. Housekeeping may be required.'}
+        4   { Write-Output 'Mismatched files/directories detected. Housekeeping may be required.'}
+        8   { Write-Error 'Some files/directories could not be copied'}
+        10  { Write-Error 'Usage error or an error due to insufficient access privileges'}
+    }
+
+    exit ($LastExitCode -band 24)
+}

--- a/Tests/Invoke-PSDeploy.Tests.ps1
+++ b/Tests/Invoke-PSDeploy.Tests.ps1
@@ -149,7 +149,7 @@ InModuleScope 'PSDeploy' {
             Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeployPathWithSpaces.psdeploy.ps1" -Force
 
             It 'Should deploy path with spaces' {
-                $Results = Test-Path (Join-Path -Path $IntegrationTarget -ChildPath 'Has Spaces.txt')
+                $Results = Test-Path (Join-Path -Path $IntegrationTarget -ChildPath 'So Does This One\Has Spaces.txt')
                 $Results | Should Be $True
             }
         }

--- a/Tests/Invoke-PSDeploy.Tests.ps1
+++ b/Tests/Invoke-PSDeploy.Tests.ps1
@@ -144,5 +144,14 @@ InModuleScope 'PSDeploy' {
                 $Results | Should Be $True                
             }
         }
+
+        Context 'Handling paths with spaces' {
+            Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeployPathWithSpaces.psdeploy.ps1" -Force
+
+            It 'Should deploy path with spaces' {
+                $Results = Test-Path (Join-Path -Path $IntegrationTarget -ChildPath 'Has Spaces.txt')
+                $Results | Should Be $True
+            }
+        }
     }
 }

--- a/Tests/artifacts/DeployPathWithSpaces.psdeploy.ps1
+++ b/Tests/artifacts/DeployPathWithSpaces.psdeploy.ps1
@@ -1,0 +1,10 @@
+Deploy Folder {
+    By Filesystem {
+        FromSource 'Modules\This Path\'
+        To TestDrive:\
+        WithOptions @{
+            Mirror = $False
+        }
+        Tagged Testing
+    }
+}

--- a/Tests/artifacts/DeployPathWithSpaces.psdeploy.ps1
+++ b/Tests/artifacts/DeployPathWithSpaces.psdeploy.ps1
@@ -1,7 +1,7 @@
 Deploy Folder {
     By Filesystem {
         FromSource 'Modules\This Path\'
-        To TestDrive:\
+        To 'TestDrive:\So Does This One\'
         WithOptions @{
             Mirror = $False
         }


### PR DESCRIPTION
Invoke-Robocopy function wraps around Robocopy.exe to control exit codes and handle trailing backslashes.
