### PR TITLE
New Invoke-Robocopy based on Start-ConsoleProcess

### DIFF
--- a/PSDeploy/Private/Invoke-Robocopy.ps1
+++ b/PSDeploy/Private/Invoke-Robocopy.ps1
@@ -1,60 +1,152 @@
-function Invoke-Robocopy () {
-    [cmdletbinding()]
-    param (
-        # Copy from location
-        [Parameter(Mandatory=$true)]
-        [string]
-        $Path,
+<#
+.Synopsis
+    Wrapper function for robocopy.exe
 
-        # Copy to location
-        [Parameter(Mandatory=$true)]
-        $Destination,
+.Parameter Path
+    String. Source path. You can use relative path.
 
-        # List of arguments to be splatted to ROBOCOPY
-        [Parameter(Mandatory=$false)]
-        [array]
-        $ArgumentList,
+.Parameter Destination
+    Array of destination paths. You can use relative paths.
 
-        # How many times should it retry
-        [Parameter(Mandatory=$false)]
-        [int]
-        $Retry = 2,
+.Parameter ArgumentList
+    Array of additional arguments for robocopy.exe
 
-        # Output file for robocopy log
-        [Parameter(Mandatory=$false)]
-        [string]
-        $OutputFile = '.\Robocopy.log',
-        
-        # Exit function if robocode throws "terminating" error code
-        [Parameter(Mandatory=$false)]
-        [switch]
-        $EnableExit
+.Parameter Retry
+    Integer. Number of retires. Default is 2.
+
+.Parameter EnableExit
+    Switch. Exit function if Robocopy throws "terminating" error code.
+
+.Parameter PassThru
+    Switch. Returns an object with the following properties:
+
+    StdOut - array of strings captured from StandardOutput 
+    StdErr - array of strings captured from StandardError 
+    ExitCode - Enum with Robocopy exit code in human-readable format
+    
+    By default, this function doesn't generate any output.
+
+.Link
+    https://technet.microsoft.com/en-us/library/cc733145.aspx
+
+.Link
+    http://ss64.com/nt/robocopy.html
+
+.Link
+    http://ss64.com/nt/robocopy-exit.html
+
+.Example
+    'c:\bravo', 'c:\charlie' | Invoke-Robocopy -Path 'c:\alpha' -ArgumentList @('/xo', '/e' )
+
+    Copy 'c:\alpha' to 'c:\bravo' and 'c:\charlie'. Copy subdirectories, include empty directories, exclude older files.
+#>
+function Invoke-Robocopy
+{
+    [CmdletBinding()]
+    Param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateScript({Test-Path -Path $_})]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [string[]]$Destination,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string[]]$ArgumentList,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [int]$Retry = 2,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]$EnableExit,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]$PassThru
     )
 
-    # Remove trailing backslash
-    $Path = $Path -replace '\\$'
-    $Path = '"' + $Path + '"'
-    $Destination = $Destination -replace '\\$'
-    $Destination = '"' + $Destination + '"'
+    Begin
+    {
+        # https://learn-powershell.net/2016/03/07/building-a-enum-that-supports-bit-fields-in-powershell/
+        function New-RobocopyHelper
+        {
+            $TypeName = 'Robocopy.ExitCode'
 
-    # Add Retries to ArgumentList
-    $ArgumentList += "/R:$Retry"
+            # http://stackoverflow.com/questions/16552801/how-do-i-conditionally-add-a-class-with-add-type-typedefinition-if-it-isnt-add
+            if (! ([System.Management.Automation.PSTypeName]$TypeName).Type) {
+                try {
+                    #region Module Builder
+                    $Domain = [System.AppDomain]::CurrentDomain
+                    $DynAssembly = New-Object -TypeName System.Reflection.AssemblyName($TypeName)
+                    $AssemblyBuilder = $Domain.DefineDynamicAssembly($DynAssembly, [System.Reflection.Emit.AssemblyBuilderAccess]::Run) # Only run in memory
+                    $ModuleBuilder = $AssemblyBuilder.DefineDynamicModule($TypeName, $false)
+                    #endregion Module Builder
 
-    # ROBOCOPY.exe $Path $Destination @ArgumentList
-    Start-Process -FilePath ROBOCOPY.exe -ArgumentList "$Path $Destination $ArgumentList" -RedirectStandardOutput $OutputFile -NoNewWindow -Wait
-    
-    # Check Log File
-    $RobocopyLog = Get-Content $OutputFile
-    $RobocopyErrors = $RobocopyLog | Select-String -Pattern 'ERROR'
-    if ($RobocopyErrors) {
-        if ($EnableExit) {
-            $host.SetShouldExit(1)
-        } else {
-            foreach ($RobocopyError in $RobocopyErrors) {
-                Write-Error $RobocopyError
+                    # https://pshirwin.wordpress.com/2016/03/18/robocopy-exitcodes-the-powershell-way/
+                    #region Enum
+                    $EnumBuilder = $ModuleBuilder.DefineEnum($TypeName, 'Public', [int32])
+                    [void]$EnumBuilder.DefineLiteral('NoChange', [int32]0x00000000)
+                    [void]$EnumBuilder.DefineLiteral('OKCopy', [int32]0x00000001)
+                    [void]$EnumBuilder.DefineLiteral('ExtraFiles', [int32]0x00000002)
+                    [void]$EnumBuilder.DefineLiteral('MismatchedFilesFolders', [int32]0x00000004)
+                    [void]$EnumBuilder.DefineLiteral('FailedCopyAttempts', [int32]0x00000008)
+                    [void]$EnumBuilder.DefineLiteral('FatalError', [int32]0x000000010)
+                    $EnumBuilder.SetCustomAttribute(
+                        [FlagsAttribute].GetConstructor([Type]::EmptyTypes),
+                        @()
+                    )
+                    [void]$EnumBuilder.CreateType()
+                    #endregion Enum
+                } catch {
+                    throw $_
+                }
             }
         }
-    } else {
-        Write-Output $RobocopyLog
+
+        New-RobocopyHelper
+    }
+
+    Process
+    {
+        foreach ($item in $Destination) {
+            # Resolve destination paths, remove trailing backslash, add Retries and combine all arguments into one array
+            $AllArguments = @(
+                (Resolve-Path -Path $Path) -replace '\\+$'
+            ) + (
+                $item | ForEach-Object {
+                    $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($_) -replace '\\+$'
+                }
+            ) + $ArgumentList + "/R:$Retry"
+
+            # Invoke Robocopy
+            $Result = Start-ConsoleProcess -FilePath 'robocopy.exe' -ArgumentList $AllArguments
+            $Result.ExitCode = [Robocopy.ExitCode]$Result.ExitCode
+    
+            # Dump Robocopy log to Verbose stream
+            $Result.StdOut | Write-Verbose
+
+            # Process Robocopy exit code
+            # http://latkin.org/blog/2012/07/08/using-enums-in-powershell/
+            if ($Result.ExitCode -band [Robocopy.ExitCode]'FailedCopyAttempts, FatalError') {
+                if ($EnableExit) {
+                    $host.SetShouldExit(1)
+                } else {
+                    $ErrorMessage =  @($Result.ExitCode) + (
+                        # Try to provide additional info about error.
+                        # WARNING: This WILL fail in localized Windows. E.g., "Œÿ»¡ ¿" in Russian.
+                        $Result.StdOut | Select-String -Pattern '\s*ERROR\s+:\s+(.+)' | ForEach-Object {
+                            $_.Matches.Groups[1].Value
+                        }
+                    )
+
+                    $ErrorMessage -join [System.Environment]::NewLine | Write-Error
+                }
+            } else {
+                # Passthru Robocopy result
+                if ($PassThru) {
+                    $Result
+                }
+            }
+        }
     }
 }

--- a/PSDeploy/Private/Start-ConsoleProcess.ps1
+++ b/PSDeploy/Private/Start-ConsoleProcess.ps1
@@ -1,0 +1,199 @@
+<#
+.Synopsis
+    Launch console process, pipe strings to its StandardInput
+    and get resulting StandardOutput/StandardError streams and exit code.
+
+.Description
+    This function will start console executable, pipe any user-specified strings to it
+    and capture StandardOutput/StandardError streams and exit code.
+    It returns object with following properties:
+
+    StdOut - array of strings captured from StandardOutput 
+    StdErr - array of strings captured from StandardError 
+    ExitCode - exit code set by executable
+
+.Parameter FilePath
+    Path to the executable or its name.
+
+.Parameter ArgumentList
+    Array of arguments for the executable.
+    Passing arguments as an array allows to run even such unfriendly applications as robocopy.
+
+.Parameter InputObject
+    Array of strings to be piped to the executable's StandardInput.
+    This allows you to execute commands in interactive sessions of netsh and diskpart.
+
+.Example
+    Start-ConsoleProcess -FilePath find
+
+    Start find.exe and capture its output.
+    Because no arguments specified, find.exe prints error to StandardError stream,
+    which is captured by the function:
+
+    StdOut StdErr                               ExitCode
+    ------ ------                               --------
+    {}     {FIND: Parameter format not correct}        2
+
+.Example
+    'aaa', 'bbb', 'ccc' | Start-ConsoleProcess -FilePath find -ArgumentList '"aaa"'
+
+    Start find.exe, pipe strings to its StandardInput and capture its output.
+    Find.exe will attempt to find string "aaa" in StandardInput stream and
+    print matches to StandardOutput stream, which is captured by the function:
+
+    StdOut StdErr ExitCode
+    ------ ------ --------
+    {aaa}  {}            0
+
+.Example
+    'list disk', 'list volume' | Start-ConsoleProcess -FilePath diskpart
+
+    Start diskpart.exe, pipe string to its StandardInput and capture its output.
+    Diskpart.exe will accept piped strings as if they were typed in the interactive session
+    and list all disks and volumes on the PC.
+
+    Note that running diskpart requires already elevated PowerShell console.
+    Otherwise, you will recieve elevation request and diskpart will run,
+    however, no strings would be piped to it.
+
+    Example:
+
+    PS > $Result = 'list disk', 'list volume' | Start-ConsoleProcess -FilePath diskpart
+    PS > $Result.StdOut
+
+    Microsoft DiskPart version 6.3.9600
+
+    Copyright (C) 1999-2013 Microsoft Corporation.
+    On computer: HAL9000
+
+    DISKPART> 
+      Disk ###  Status         Size     Free     Dyn  Gpt
+      --------  -------------  -------  -------  ---  ---
+      Disk 0    Online          298 GB      0 B         
+
+    DISKPART> 
+      Volume ###  Ltr  Label        Fs     Type        Size     Status     Info
+      ----------  ---  -----------  -----  ----------  -------  ---------  --------
+      Volume 0     E                       DVD-ROM         0 B  No Media           
+      Volume 1     C   System       NTFS   Partition    100 GB  Healthy    System  
+      Volume 2     D   Storage      NTFS   Partition    198 GB  Healthy            
+
+    DISKPART> 
+
+.Example
+    Start-ConsoleProcess -FilePath robocopy -ArgumentList 'C:\Src', 'C:\Dst', '/mir'
+
+    Start robocopy.exe with arguments and capture its output.
+    Robocopy.exe will mirror contents of the 'C:\Src' folder to 'C:\Dst'
+    and print log to StandardOutput stream, which is captured by the function.
+
+    Example:
+
+    PS > $Result = Start-ConsoleProcess -FilePath robocopy -ArgumentList 'C:\Src', 'C:\Dst', '/mir'
+    PS > $Result.StdOut
+
+    -------------------------------------------------------------------------------
+       ROBOCOPY     ::     Robust File Copy for Windows                              
+    -------------------------------------------------------------------------------
+
+      Started : 01 January 2016 y. 00:00:01
+       Source : C:\Src\
+         Dest : C:\Dst\
+
+        Files : *.*
+	    
+      Options : *.* /S /E /DCOPY:DA /COPY:DAT /PURGE /MIR /R:1000000 /W:30 
+
+    ------------------------------------------------------------------------------
+
+	                       1	C:\Src\
+	        New File  		       6	Readme.txt
+      0%  
+    100%  
+
+    ------------------------------------------------------------------------------
+
+                   Total    Copied   Skipped  Mismatch    FAILED    Extras
+        Dirs :         1         0         0         0         0         0
+       Files :         1         1         0         0         0         0
+       Bytes :         6         6         0         0         0         0
+       Times :   0:00:00   0:00:00                       0:00:00   0:00:00
+
+
+       Speed :                 103 Bytes/sec.
+       Speed :               0.005 MegaBytes/min.
+       Ended : 01 January 2016 y. 00:00:01
+#>
+function Start-ConsoleProcess
+{
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$FilePath,
+
+        [string[]]$ArgumentList,
+
+        [Parameter(ValueFromPipeline = $true)]
+        [string[]]$InputObject
+    )
+
+    End
+    {
+        if($Input)
+        {
+            # Collect all pipeline input
+            # http://www.powertheshell.com/input_psv3/
+            $StdIn = @($Input)
+        }
+        else
+        {
+            $StdIn = $InputObject
+        }
+
+        try
+        {
+            "Starting process: $FilePath", "Redirect StdIn: $([bool]$StdIn.Count)", "Arguments: $ArgumentList" | Write-Verbose
+
+            if($StdIn.Count)
+            {
+                $Output = $StdIn | & $FilePath $ArgumentList 2>&1
+            }
+            else
+            {
+                $Output = & $FilePath $ArgumentList 2>&1
+            }
+        }
+        catch
+        {
+            throw $_
+        }
+
+        Write-Verbose 'Finished, processing output'
+
+        $StdOut = New-Object -TypeName System.Collections.Generic.List``1[String]
+        $StdErr = New-Object -TypeName System.Collections.Generic.List``1[String]
+
+        foreach($item in $Output)
+        {
+            # Data from StdOut will be strings, while StdErr produces
+            # System.Management.Automation.ErrorRecord objects.
+            # http://stackoverflow.com/a/33002914/4424236
+            if($item.Exception.Message)
+            {
+                $StdErr.Add($item.Exception.Message)
+            }
+            else
+            {
+                $StdOut.Add($item)
+            }
+        }
+
+        Write-Verbose 'Returning result'
+        New-Object -TypeName PSCustomObject -Property @{
+            ExitCode = $LASTEXITCODE
+            StdOut = $StdOut.ToArray()
+            StdErr = $StdErr.ToArray()
+        } | Select-Object -Property StdOut, StdErr, ExitCode
+    }
+}


### PR DESCRIPTION
Drop-in replacement for Invoke-Robocopy function.
Based on my [Start-ConsoleProcess](https://github.com/beatcracker/Powershell-Misc/blob/master/Start-ConsoleProcess.ps1) function.

Removed:
- `OutputFile` parameter

Added:
- `PassThru` parameter

This function doesn't use `Start-Process` and can get robocopy output without redirecting it to file. Additionally, it correctly handles robocopy exit code, without relying on the log parsing (no localization issues). It can also return full robocopy output including `StdOut`,`StdErr` and enum with human-friendly `ExitCode` if used with `PassThru`parameter. Unlike the original wrapper, it doesn't return robocopy output by default.
