### PR TITLE
Add Chocolatey deployment type

### DIFF
--- a/PSDeploy/PSDeploy.yml
+++ b/PSDeploy/PSDeploy.yml
@@ -11,6 +11,10 @@ ARM:
   Script: ARM.ps1
   Description: Uses Azure Resource Manager PowerShell cmdlets to deploy a template to Microsoft Azure or Azure Stack 
 
+Chocolatey:
+  Script: Chocolatey.ps1
+  Description: Uses Chocolatey on the local computer to push packages to a Chocolatey repository.
+
 CopyVMfile:
   Script: CopyVMFile.ps1
   Description: Uses Copy-VMFile cmdlet available with Hyper-V on Server 2012 R2 for folder and file deployments.

--- a/PSDeploy/PSDeployScripts/Chocolatey.ps1
+++ b/PSDeploy/PSDeployScripts/Chocolatey.ps1
@@ -73,7 +73,7 @@ foreach($Deploy in $Deployment)
         {
             $ChocolateyPackage += " --source='$target' "
             $ChocolateyPackage += " --api-key='$ApiKey' "
-            
+
             if( $PSBoundParameters.ContainsKey('Force') )
             {
                 $ChocolateyPackage += " --force "
@@ -88,7 +88,7 @@ foreach($Deploy in $Deployment)
             Write-Verbose "Chocolatey Path: $ChocolateyPath"
             Write-Verbose "Chocolatey Params are: $ChocolateyPackage "
             Write-Verbose "String executed: $ChocolateyPath push $ChocolateyPackage"
-            & $ChocolateyPath push $ChocolateyPackage
+            Invoke-expression "$ChocolateyPath push $ChocolateyPackage"
         }
 
     }

--- a/PSDeploy/PSDeployScripts/Chocolatey.ps1
+++ b/PSDeploy/PSDeployScripts/Chocolatey.ps1
@@ -1,0 +1,95 @@
+<#
+    .SYNOPSIS
+        Deploys a package to a Chocolatey repository.
+
+    .DESCRIPTION
+        Deploys a Chocolatey package to a nuget-based repository like the Chocolatey Gallery. Can also be used to deploy to a private
+        instance of Chocolatey simple server or to any nuget-based repository.
+
+    .PARAMETER Deployment
+        Deployment to run
+
+    .PARAMETER ApiKey
+        API Key used to authenticate to Chocolatey repository.
+
+    .PARAMETER Source
+        The source we are pushing the package to. Use https://chocolatey.org/ to push to [community feed](https://chocolatey.org/packages).
+
+    .PARAMETER Force
+        Force the behavior. Do not use force during normal operation - it subverts some of the smart behavior for commands.
+
+    .PARAMETER TimeOut
+        CommandExecutionTimeout (in seconds) - The time to allow a command to finish before timing out. Overrides the default execution timeout in the configuration of 2700 seconds.
+
+
+#>
+[cmdletbinding()]
+param(
+    [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [psobject[]]$Deployment,
+
+    [Parameter(Mandatory)]
+    [string]$ApiKey,
+
+    [switch]$Force,
+
+    [int]$TimeOut
+)
+
+foreach($Deploy in $Deployment)
+{
+    # Getting the path to the Chocolatey executable from the environment variable Chocolatey sets.
+    # If this variable doesn't exist, then Chocolatey may not be installed or is an older version.
+    if($null -eq $env:ChocolateyInstall)
+    {
+        Throw "Chocolatey either isn't installed or an older version is being used. Can't find ChocolateyInstall environment variable."
+    }
+    $ChocolateyPath = $env:ChocolateyInstall + "\choco.exe"
+
+    foreach($target in $deploy.Targets)
+    {
+        Write-Verbose -Message "Starting deployment [$($deploy.DeploymentName)] to Chocolatey repository [$Target]"
+
+        if([string]::IsNullOrEmpty($ApiKey) -and [string]::IsNullOrEmpty($deploy.DeploymentOptions.ApiKey))
+        {
+            Throw "An API key is required."
+        }
+        elseif($ApiKey -eq $null)
+        {
+            $ApiKey = $deploy.DeploymentOptions.ApiKey
+        }
+
+        # If a directory is passed in, iterate through directory pushing each nupkg
+        if($Deploy.SourceType -eq 'Directory')
+        {
+            [string[]]$ChocolateyArguments = (Get-ChildItem -Path $deploy.Source  -Filter *.nupkg).FullName
+        }
+        else
+        {
+            [string[]]$ChocolateyArguments = $deploy.Source
+        }
+
+        foreach($ChocolateyPackage in $ChocolateyArguments)
+        {
+            $ChocolateyPackage += " --source='$target' "
+            $ChocolateyPackage += " --api-key='$ApiKey' "
+            
+            if( $PSBoundParameters.ContainsKey('Force') )
+            {
+                $ChocolateyPackage += " --force "
+            }
+
+            if( $PSBoundParameters.ContainsKey('TimeOut') )
+            {
+                $ChocolateyPackage += " -t=$timeout "
+            }
+
+            Write-Verbose "Invoking Chocolatey Push."
+            Write-Verbose "Chocolatey Path: $ChocolateyPath"
+            Write-Verbose "Chocolatey Params are: $ChocolateyPackage "
+            Write-Verbose "String executed: $ChocolateyPath push $ChocolateyPackage"
+            & $ChocolateyPath push $ChocolateyPackage
+        }
+
+    }
+}

--- a/Tests/PSDeploy.Tests.ps1
+++ b/Tests/PSDeploy.Tests.ps1
@@ -24,7 +24,7 @@ Import-Module $PSScriptRoot\..\$ModuleName -Force
     $FolderPS1 = "$PSScriptRoot\artifacts\IntegrationFolder.PSDeploy.ps1"
     $CopyVMYML = "$PSScriptRoot\artifacts\DeploymentsCopyVMFile.yml"
     $CopyVMFolderYML= "$PSScriptRoot\artifacts\DeploymentsCopyVMFolder.yml"
-    $PSGalleryModulePS1 = "$PSScriptRoot\artifacts\DeploymentsPSGalleryModule.psdeploy.ps1" 
+    $PSGalleryModulePS1 = "$PSScriptRoot\artifacts\DeploymentsPSGalleryModule.psdeploy.ps1"
 
     $WaitForFilesystem = .5
     $MyVariable = 42
@@ -91,7 +91,7 @@ Describe "Get-PSDeploymentType PS$PSVersion" {
         It 'Should get definitions' {
             $Definitions = @( Get-PSDeploymentType @Verbose )
 
-            $Definitions.Count | Should Be 9
+            $Definitions.Count | Should Be 10
             $Definitions.DeploymentType -contains 'FileSystem' | Should Be $True
             $Definitions.DeploymentType -contains 'FileSystemRemote' | Should Be $True
             $Definitions.DeploymentType -contains 'CopyVMfile' | Should Be $True
@@ -119,7 +119,7 @@ Describe "Get-PSDeploymentScript PS$PSVersion" {
         It 'Should get definitions' {
             $Definitions = Get-PSDeploymentScript @Verbose
 
-            $Definitions.Keys.Count | Should Be 9
+            $Definitions.Keys.Count | Should Be 10
             $Definitions.GetType().Name | Should Be 'Hashtable'
             $Definitions.ContainsKey('FileSystem') | Should Be $True
             $Definitions.ContainsKey('FileSystemRemote') | Should Be $True
@@ -283,14 +283,14 @@ Describe "Invoke-PSDeployment PS$PSVersion" {
 
         It 'Should copy file to VM' {
             Mock -CommandName Copy-VMFile -MockWith {}   -ModuleName PSdeploy
-            $deployment = Get-PSDeployment @Verbose -Path $CopyVMYML 
+            $deployment = Get-PSDeployment @Verbose -Path $CopyVMYML
             Invoke-PSDeployment -Deployment $deployment  @Verbose -Force
             Assert-MockCalled -CommandName Copy-VMfile -Times 1 -Exactly -ModuleName PSDeploy
         }
 
         It 'Should copy folder to VM' {
             Mock -CommandName Copy-VMFile -MockWith {}  -ModuleName PSDeploy
-            $Deployment = Get-PSDeployment @Verbose -Path $CopyVMFolderYML 
+            $Deployment = Get-PSDeployment @Verbose -Path $CopyVMFolderYML
             Invoke-PSDeployment -Deployment $Deployment @Verbose -Force
             $TotalFiles = Get-Childitem -Path $Deployment.Source -File -Recurse
             $count = $TotalFiles.Count  # had to factor that Pester stores the mock history of the last Mock command too
@@ -392,4 +392,3 @@ Remove-Item -Path $FilePS1 -force
 Remove-Item -Path $FolderPS1 -force
 Remove-Item -Path $IntegrationTarget -Recurse -Force
 Remove-Module -Name Hyper-V -Force
-

--- a/docs/Example-Chocolatey-Deployment.md
+++ b/docs/Example-Chocolatey-Deployment.md
@@ -1,0 +1,51 @@
+# Overview
+Chocolatey is an open source package manager for Windows. It's built on top of the Nuget framework which allows for storing the packages in a repository. For more information on what Chocolatey is you can learn more at the [Chocolatey website](https://chocolatey.org/) or the [Github Page](https://github.com/chocolatey/choco).
+
+There is a community feed available, but most organizations host their own private repositories. For more information on setting up your own repository see [How To Host Your Own Package Repository Server](https://chocolatey.org/docs/how-to-host-feed).
+
+# Prerequisites
+The local system must have Chocolatey installed in order to do the deployment.
+
+# Options
+The options ApiKey and Force map directly to the ApiKey and Force parameters in the [choco push command](https://chocolatey.org/docs/commands-push).
+
+# Examples
+## Deploying a single package
+### SingleChocolateyPackage.PSDeploy.ps1
+
+Here's an example Deployment config:
+
+```PowerShell
+Deploy SingleChocolateyPackage {
+    By Chocolatey {
+        FromSource 'c:\ChocolateyPackages\examplepackage.0.1.1.nupkg'
+        To "http://your-choco-repo.internal.com/"
+        WithOptions @{
+            ApiKey = 'yourAPIkey'
+            Force = $true
+        }
+    }
+}
+```
+
+This deployment takes the file `examplepackage.0.1.1.nupkg` from the specified location and runs choco push to deploy the package to the internal repository.
+
+## Deploying a group of packages from a directory
+### DirectoryChocolateyPackage.PSDeploy.ps1
+
+This example shows using Unicode as the Encoding.
+
+```PowerShell
+Deploy DirectoryChocolateyPackage {
+    By Chocolatey {
+      FromSource 'c:\ChocolateyPackages'
+      To "http://your-choco-repo.internal.com/"
+      WithOptions @{
+          ApiKey = 'yourAPIkey'
+          Force = $true
+      }
+  }
+}
+```
+
+This deployment pulls all of the nupkg files from the directory `c:\ChocolateyPackages` and pushes each  package to the internal repository.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ pages:
     - PSDeploy Configuration Files: PSDeploy-Configuration-Files.md
   - DeploymentType Examples:
     - Artifactory Deployment: Example-Artifactory-Deployment.md
+    - Chocolatey Deployment: Example-Chocolatey-Deployment.md
     - FileSystem Deployment: Example-Filesystem-Deployment.md
     - Filesystem Deployment Follow Along: Example-Filesystem-Deployment-Follow-Along.md
     - FilesystemRemote Deployment: Example-FilesystemRemote-Deployment.md


### PR DESCRIPTION
This is to create a deployment type to push chocolatey packages to Chocolatey repos. It can take a single file or push all the nupkgs in a directory.