### PR TITLE
Add FileSystemDiff deployment type

### DIFF
--- a/PSDeploy/PSDeploy.yml
+++ b/PSDeploy/PSDeploy.yml
@@ -30,6 +30,10 @@ Filesystem:
 FilesystemRemote:
   Script: FilesystemRemote.ps1
   Description: Uses a PowerShell remoting endpoint and Robocopy or Copy-Item for folder and file deployments, respectively.
+  
+FileSystemDiff:
+  Script: FileSystemDiff.ps1
+  Description: Uses the current session to Copy-Item for folder or file deployments, but will check if the target file is different from last deployment.
 
 Git:
   Script: Git.ps1

--- a/PSDeploy/PSDeployScripts/FileSystemDiff.ps1
+++ b/PSDeploy/PSDeployScripts/FileSystemDiff.ps1
@@ -1,0 +1,121 @@
+﻿<#
+    .SYNOPSIS
+        Deploy using Copy-Item for folder and file deployments checking for code differences
+
+    .DESCRIPTION
+        Deploy files using Copy-Item, but first check if the code in the destination file has changed
+        since the last deployment.  
+
+        Scenarios:
+            1. File does not exist at destination:  Copy from code control.  Create a hash file.
+            2. File exists at destination, but no hash file:  Copy from code control.  Create a hash file.
+            3. File exists at destination, matching hash file: Copy from code control.  Create a new hash file.
+            4. File exists at destination, hash file does not match: two scenario's here:
+                a. SaveDiff not set: Show warning that destination file is different.  Overwrite from code control.  Create new hash file.
+                b. SaveDiff set: Show warning. Rename destination file. Copy from code control. Create new hash file.
+
+    .PARAMETER Deployment
+        Deployment to run
+
+    .PARAMETER SaveDiff
+        If a difference between the target file, and the target files saved hash is different that means
+        the target file was changed outside of code control.  Use this option to save the file before overwriting
+        it with the proper file from code control.
+#>
+[CmdletBinding()]
+Param (
+    [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [psobject[]]$Deployment,
+
+    [switch]$SaveDiff
+)
+
+Write-Verbose "Starting local deployment with $($Deployment.count) sources"
+
+#Local Deployment. Duplicate code. Sigh.
+ForEach ($Map in $Deployment)
+{
+    If ($Map.SourceExists)
+    {
+        If ($Map.SourceType -eq "Directory")
+        {
+            $Files = Get-ChildItem $Map.Source -Recurse -File
+        }
+        Else 
+        {
+            $Files = @(Get-ItemProperty $Map.Source)
+        }
+        ForEach ($File in $Files)
+        {
+            ForEach ($Target in $Map.Targets)
+            {
+
+
+                
+                Write-Verbose "Deploying file '$($Map.Source)' to '$Target'"
+                Copy-Item -Path $File.FullName -Destination $Target -Force
+            }
+
+            $HashFilePath = Join-Path -Path ($File.Directory) -ChildPath "$($File.BaseName).hash"
+            If (Test-Path $HashFilePath)
+            {
+                $OldHash = Import-Clixml -Path $HashFilePath
+
+            }
+            Else
+            {
+                $Hash = [PSCustomObject]@{
+                    Hash = Get-FileHash -Path $File.FullName | Select -ExpandProperty Hash
+                    File = $null #Get-Content $File.FullName  #future proofing in case you want to see the difference
+                }
+                $Hash | Export-Clixml -Path $HashFilePath
+            }
+
+        }
+
+
+
+
+
+        $Targets = $Map.Targets
+        ForEach ($Target in $Targets)
+        {
+            If ($Map.SourceType -eq 'Directory')
+            {
+                $Files = Get-ChildItem $Target -File -Recurse
+            }
+            Else 
+
+            {
+                $Files = 
+            }
+            Else
+
+            {
+                $SourceHash = ( Get-Hash $Map.Source ).SHA256
+                $TargetHash = ( Get-Hash $Target -ErrorAction SilentlyContinue -WarningAction SilentlyContinue ).SHA256
+                if($SourceHash -ne $TargetHash)
+                {
+                    Write-Verbose "Deploying file '$($Map.Source)' to '$Target'"
+                    Try {
+                        Copy-Item -Path $Map.Source -Destination $Target -Force
+                    }
+                    Catch [System.IO.IOException],[System.IO.DirectoryNotFoundException] {
+                        $NewDir = $Target
+                        if ($NewDir[-1] -ne '\')
+                        {
+                            $NewDir = Split-Path -Path $NewDir
+                        }
+                        $null = New-Item -ItemType Directory -Path $NewDir
+                        Copy-Item -Path $Map.Source -Destination $Target -Force
+                    }
+                }
+                Else
+
+                {
+                    Write-Verbose "Skipping deployment with matching hash: '$($Map.Source)' = '$Target')"
+                }
+            }
+        }
+    }
+}

--- a/Tests/Types/FileSystemDiff.tests.ps1
+++ b/Tests/Types/FileSystemDiff.tests.ps1
@@ -1,0 +1,138 @@
+Remove-Module PSDeploy -ErrorAction SilentlyContinue
+Import-Module $PSScriptRoot\..\..\PSDeploy\PSDeploy.psd1
+Set-BuildEnvironment -Path $PSScriptRoot   #\..\..
+
+InModuleScope 'PSDeploy' {
+    $ProjectRoot = $ENV:BHProjectPath
+    #Make sure dest path does not exist
+    Remove-Item $ENV:BHProjectPath\dest -Recurse -Force -ErrorAction SilentlyContinue
+
+
+    Describe "Single File Deployment tests" {
+        Context "Single Copy" {
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
+
+            It "Test1 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
+            }
+            It "Test1 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt.hash | Should Be $true
+            }
+        }
+        Context "Single Copy, destination present, no hash" {
+            Remove-Item -Path $ENV:BHProjectPath\Dest\test1.txt.hash
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
+
+            It "Test1 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
+            }
+            It "Test1 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt.hash | Should Be $true
+            }
+        }
+        Context "Single Copy, destination present, matching hash" {
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
+
+            It "Test1 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
+            }
+            It "Test1 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt.hash | Should Be $true
+            }
+        }
+        Context "Single Copy, destination present, non-matching hash with SaveDiff" {
+            "This is a test" | Add-Content -Path $ENV:BHProjectPath\Dest\test1.txt
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
+
+            It "Test1 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
+            }
+            It "Test1 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt.hash | Should Be $true
+            }
+            It "Test1 Saved file present" {
+                Test-Path $ENV:BHProjectPath\dest\test1-*.txt | Should Be $true
+            }
+        }
+    }
+
+    Describe "Directory File Deployments" {
+        Context "Folder Copy, destination not present" {
+            Remove-Item $ENV:BHProjectPath\dest -Recurse -Force -ErrorAction SilentlyContinue
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
+
+            It "Test1 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
+            }
+            It "Test2 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test2.txt | Should Be $true
+            }
+            It "Test1 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt.hash | Should Be $true
+            }
+            It "Test2 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test2.txt.hash | Should Be $true
+            }
+        }
+        Context "Folder Copy, destination present, no hash" {
+            Remove-Item $ENV:BHProjectPath\dest\*.hash -Force -ErrorAction SilentlyContinue
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
+
+            It "Test1 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
+            }
+            It "Test2 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test2.txt | Should Be $true
+            }
+            It "Test1 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt.hash | Should Be $true
+            }
+            It "Test2 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test2.txt.hash | Should Be $true
+            }
+        }
+        Context "Folder Copy, destination present, matching hash" {
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
+
+            It "Test1 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
+            }
+            It "Test2 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test2.txt | Should Be $true
+            }
+            It "Test1 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt.hash | Should Be $true
+            }
+            It "Test2 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test2.txt.hash | Should Be $true
+            }
+        }
+        Context "Folder Copy, destination present, non-matching hash" {
+            "This is a test" | Add-Content -Path $ENV:BHProjectPath\Dest\test1.txt
+            "This is a test" | Add-Content -Path $ENV:BHProjectPath\Dest\test2.txt
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
+
+            It "Test1 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
+            }
+            It "Test2 Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test2.txt | Should Be $true
+            }
+            It "Test1 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test1.txt.hash | Should Be $true
+            }
+            It "Test2 Hash Present" {
+                Test-Path $ENV:BHProjectPath\Dest\test2.txt.hash | Should Be $true
+            }
+            It "Test1 Saved file present" {
+                Test-Path $ENV:BHProjectPath\dest\test1-*.txt | Should Be $true
+            }
+            It "Test2 Saved file present" {
+                Test-Path $ENV:BHProjectPath\dest\test2-*.txt | Should Be $true
+            }
+        }
+    }
+}
+
+#Final cleanup
+Remove-Item $ENV:BHProjectPath\dest -Recurse -Force -ErrorAction SilentlyContinue

--- a/Tests/Types/FileSystemDiff.tests.ps1
+++ b/Tests/Types/FileSystemDiff.tests.ps1
@@ -1,6 +1,6 @@
 Remove-Module PSDeploy -ErrorAction SilentlyContinue
 Import-Module $PSScriptRoot\..\..\PSDeploy\PSDeploy.psd1
-Set-BuildEnvironment -Path $PSScriptRoot   #\..\..
+Set-BuildEnvironment -Path $PSScriptRoot\..\..
 
 InModuleScope 'PSDeploy' {
     $ProjectRoot = $ENV:BHProjectPath
@@ -8,9 +8,9 @@ InModuleScope 'PSDeploy' {
     Remove-Item $ENV:BHProjectPath\dest -Recurse -Force -ErrorAction SilentlyContinue
 
 
-    Describe "Single File Deployment tests" {
+    Describe "FileSystemDiff: Single File Deployment tests" {
         Context "Single Copy" {
-            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\Tests\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
 
             It "Test1 Present" {
                 Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
@@ -21,7 +21,7 @@ InModuleScope 'PSDeploy' {
         }
         Context "Single Copy, destination present, no hash" {
             Remove-Item -Path $ENV:BHProjectPath\Dest\test1.txt.hash
-            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\Tests\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
 
             It "Test1 Present" {
                 Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
@@ -31,7 +31,7 @@ InModuleScope 'PSDeploy' {
             }
         }
         Context "Single Copy, destination present, matching hash" {
-            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\Tests\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
 
             It "Test1 Present" {
                 Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
@@ -42,7 +42,7 @@ InModuleScope 'PSDeploy' {
         }
         Context "Single Copy, destination present, non-matching hash with SaveDiff" {
             "This is a test" | Add-Content -Path $ENV:BHProjectPath\Dest\test1.txt
-            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\Tests\Artifacts\FileSystemSingleDeploy.PSDeploy.ps1 -Force
 
             It "Test1 Present" {
                 Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
@@ -56,10 +56,10 @@ InModuleScope 'PSDeploy' {
         }
     }
 
-    Describe "Directory File Deployments" {
+    Describe "FileSystemDiff: Directory File Deployments" {
         Context "Folder Copy, destination not present" {
             Remove-Item $ENV:BHProjectPath\dest -Recurse -Force -ErrorAction SilentlyContinue
-            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\Tests\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
 
             It "Test1 Present" {
                 Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
@@ -76,7 +76,7 @@ InModuleScope 'PSDeploy' {
         }
         Context "Folder Copy, destination present, no hash" {
             Remove-Item $ENV:BHProjectPath\dest\*.hash -Force -ErrorAction SilentlyContinue
-            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\Tests\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
 
             It "Test1 Present" {
                 Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
@@ -92,7 +92,7 @@ InModuleScope 'PSDeploy' {
             }
         }
         Context "Folder Copy, destination present, matching hash" {
-            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\Tests\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
 
             It "Test1 Present" {
                 Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true
@@ -110,7 +110,7 @@ InModuleScope 'PSDeploy' {
         Context "Folder Copy, destination present, non-matching hash" {
             "This is a test" | Add-Content -Path $ENV:BHProjectPath\Dest\test1.txt
             "This is a test" | Add-Content -Path $ENV:BHProjectPath\Dest\test2.txt
-            Invoke-PSDeploy -Path $ENV:BHProjectPath\..\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
+            Invoke-PSDeploy -Path $ENV:BHProjectPath\Tests\Artifacts\FileSystemFolderDeploy.PSDeploy.ps1 -Force
 
             It "Test1 Present" {
                 Test-Path $ENV:BHProjectPath\Dest\test1.txt | Should Be $true

--- a/Tests/Types/FileSystemDiffSource/test1.txt
+++ b/Tests/Types/FileSystemDiffSource/test1.txt
@@ -1,0 +1,16 @@
+SQL Server Name   ........................ E9-TRACEIT
+SQL Database Name ........................ TRACEIT
+Backup Method     ........................ Lgcy
+Backup Location   ........................ Srv
+Backup Object Type ....................... Full
+Backup on Secondary Replica .............. No
+Backup Object State ...................... Active
+Backup Creation Date / Time .............. 02/15/2014 02:00:37
+Backup Size .............................. 90.31 MB
+SQL Compressed ........................... Yes
+Backup Compressed ........................ No
+Backup Encryption Type ................... None
+Backup Client-deduplicated ............... No
+Database Object Name ..................... 20140215020037\00002C26
+Number of stripes in backup object ....... 5
+Assigned Management Class  ............... DEFAULT

--- a/Tests/Types/FileSystemDiffSource/test2.txt
+++ b/Tests/Types/FileSystemDiffSource/test2.txt
@@ -1,0 +1,37 @@
+Just another test file
+
+To be, or not to be--that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune
+Or to take arms against a sea of troubles
+And by opposing end them. To die, to sleep--
+No more--and by a sleep to say we end
+The heartache, and the thousand natural shocks
+That flesh is heir to. 'Tis a consummation
+Devoutly to be wished. To die, to sleep--
+To sleep--perchance to dream: ay, there's the rub,
+For in that sleep of death what dreams may come
+When we have shuffled off this mortal coil,
+Must give us pause. There's the respect
+That makes calamity of so long life.
+For who would bear the whips and scorns of time,
+Th' oppressor's wrong, the proud man's contumely
+The pangs of despised love, the law's delay,
+The insolence of office, and the spurns
+That patient merit of th' unworthy takes,
+When he himself might his quietus make
+With a bare bodkin? Who would fardels bear,
+To grunt and sweat under a weary life,
+But that the dread of something after death,
+The undiscovered country, from whose bourn
+No traveller returns, puzzles the will,
+And makes us rather bear those ills we have
+Than fly to others that we know not of?
+Thus conscience does make cowards of us all,
+And thus the native hue of resolution
+Is sicklied o'er with the pale cast of thought,
+And enterprise of great pitch and moment
+With this regard their currents turn awry
+And lose the name of action. -- Soft you now,
+The fair Ophelia! -- Nymph, in thy orisons
+Be all my sins remembered.

--- a/Tests/artifacts/FileSystemFolderDeploy.PSDeploy.ps1
+++ b/Tests/artifacts/FileSystemFolderDeploy.PSDeploy.ps1
@@ -2,7 +2,7 @@
 
 Deploy FileSystemDiffTest {
     By FileSystemDiff {
-        FromSource "$ENV:BHProjectPath\FileSystemDiffSource"
+        FromSource "$ENV:BHProjectPath\Tests\Types\FileSystemDiffSource"
         To "$ENV:BHProjectPath\Dest"
         WithOptions @{
             SaveDiff = $true

--- a/Tests/artifacts/FileSystemFolderDeploy.PSDeploy.ps1
+++ b/Tests/artifacts/FileSystemFolderDeploy.PSDeploy.ps1
@@ -1,0 +1,11 @@
+
+
+Deploy FileSystemDiffTest {
+    By FileSystemDiff {
+        FromSource "$ENV:BHProjectPath\FileSystemDiffSource"
+        To "$ENV:BHProjectPath\Dest"
+        WithOptions @{
+            SaveDiff = $true
+        }
+    }
+}

--- a/Tests/artifacts/FileSystemSingleDeploy.PSDeploy.ps1
+++ b/Tests/artifacts/FileSystemSingleDeploy.PSDeploy.ps1
@@ -2,7 +2,7 @@
 
 Deploy FileSystemDiffTest {
     By FileSystemDiff {
-        FromSource "$ENV:BHProjectPath\FileSystemDiffSource\test1.txt"
+        FromSource "$ENV:BHProjectPath\Tests\Types\FileSystemDiffSource\test1.txt"
         To "$ENV:BHProjectPath\Dest"
         WithOptions @{
             SaveDiff = $true

--- a/Tests/artifacts/FileSystemSingleDeploy.PSDeploy.ps1
+++ b/Tests/artifacts/FileSystemSingleDeploy.PSDeploy.ps1
@@ -1,0 +1,11 @@
+
+
+Deploy FileSystemDiffTest {
+    By FileSystemDiff {
+        FromSource "$ENV:BHProjectPath\FileSystemDiffSource\test1.txt"
+        To "$ENV:BHProjectPath\Dest"
+        WithOptions @{
+            SaveDiff = $true
+        }
+    }
+}


### PR DESCRIPTION
Deploy files using Copy-Item, but first check if the code in the destination file has changed
since the last deployment.  

Scenarios:
    1. File does not exist at destination:  Copy from code control.  Create a hash file.
    2. File exists at destination, but no hash file:  Copy from code control.  Create a hash file.
    3. File exists at destination, matching hash file: Copy from code control.  Create a new hash file.
    4. File exists at destination, hash file does not match: two scenario's here:
        a. SaveDiff not set: Show warning that destination file is different.  Overwrite from code control.  Create new hash file.
        b. SaveDiff set: Show warning. Rename destination file. Copy from code control. Create new hash file.