### PR TITLE
fixed bug in version comparison

### DIFF
--- a/PSDeploy/Private/PSYaml/PSYaml.psm1
+++ b/PSDeploy/Private/PSYaml/PSYaml.psm1
@@ -1,5 +1,5 @@
 #handle PS2
-    $ModernPS = $PSVersionTable.PSVersion -ge '3.0'
+    $ModernPS = $PSVersionTable.PSVersion -ge '3.0.0'
     if(-not $ModernPS)
     {
         $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent

--- a/PSDeploy/Private/PSYaml/PSYaml.psm1
+++ b/PSDeploy/Private/PSYaml/PSYaml.psm1
@@ -1,5 +1,5 @@
 #handle PS2
-    $ModernPS = $PSVersionTable.PSVersion -ge '3.0.0'
+    $ModernPS = $PSVersionTable.PSVersion -ge '3.0.0' -or $PSVersionTable.PSVersion -ge '3.0'
     if(-not $ModernPS)
     {
         $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
@@ -28,4 +28,4 @@
 
 Load-YamlDotNetLibraries (Join-Path $PSScriptRoot -ChildPath "Lib")
 
-Export-ModuleMember -Function ConvertFrom-Yaml 
+Export-ModuleMember -Function ConvertFrom-Yaml


### PR DESCRIPTION
This line causes a problem in Powershell Core.  Fixed it just by updating the version to 3.0.0 instead of 3.0.

Error:
The running command stopped because the preference 
variable "ErrorActionPreference" or common parameter is set to Stop: Could not compare "6.0.0-alpha" to "3.0". Error: "Cannot 
convert value "3.0" to type "System.Management.Automation.SemanticVersion". Error: "Cannot process argument because the value of 
argument "version" is not valid. Change the value of the "version" argument and run the operation again.""