### PR TITLE
New deployment types IISSite, IISAppPool and NSSM (Closes #92)

### DIFF
--- a/PSDeploy/PSDeploy.yml
+++ b/PSDeploy/PSDeploy.yml
@@ -75,6 +75,6 @@ IISSite:
   Script: IISSite.ps1
   Description: Deploys a IIS Site, by removing the Site copying the files to the Target and adding the IIS Site
 
-Node:
-  Script: Node.ps1
-  Description: Deploys a Node App by using the Non-Sucking Service Manager to run Node as a Service in Windows
+NSSM:
+  Script: NSSM.ps1
+  Description: Deploys a binary by using the Non-Sucking Service Manager to run the ninary as a service in Windows

--- a/PSDeploy/PSDeploy.yml
+++ b/PSDeploy/PSDeploy.yml
@@ -75,6 +75,10 @@ IISSite:
   Script: IISSite.ps1
   Description: Deploys a IIS Site, by removing the Site copying the files to the Target and adding the IIS Site
 
+IISAppPool:
+  Script: IISAppPool.ps1
+  Description: Deploys a IIS AppPool, by removing the AppPool and recreating it
+
 NSSM:
   Script: NSSM.ps1
   Description: Deploys a binary by using the Non-Sucking Service Manager to run the ninary as a service in Windows

--- a/PSDeploy/PSDeploy.yml
+++ b/PSDeploy/PSDeploy.yml
@@ -73,4 +73,8 @@ vSphereOVF:
 
 IISSite:
   Script: IISSite.ps1
-  Description: Removes the IIS Site, deploys the files to the Target and adds the IIS Site
+  Description: Deploys a IIS Site, by removing the Site copying the files to the Target and adding the IIS Site
+
+Node:
+  Script: Node.ps1
+  Description: Deploys a Node App by using the Non-Sucking Service Manager to run Node as a Service in Windows

--- a/PSDeploy/PSDeploy.yml
+++ b/PSDeploy/PSDeploy.yml
@@ -70,3 +70,7 @@ Task:
 vSphereOVF:
   Script: vSphereOVF.ps1
   Description: Support deployments of OVF/OVA onto a VMware vSphere infrastructure.
+
+IISSite:
+  Script: IISSite.ps1
+  Description: Removes the IIS Site, deploys the files to the Target and adds the IIS Site

--- a/PSDeploy/PSDeployScripts/IISAppPool.ps1
+++ b/PSDeploy/PSDeployScripts/IISAppPool.ps1
@@ -1,0 +1,267 @@
+<#
+    .SYNOPSIS
+        Deploys an IIS AppPool using Powershell
+
+    .DESCRIPTION
+        Deploys an IIS AppPool using Powershell
+    
+        By IISAppPool MyAppPool {
+            WithOptions @{
+                name = "AppPoolName"
+                StartMode = "AlwaysRunning"
+                IdentityType = 2
+            }
+        }
+
+    .PARAMETER Deployment
+        Deployment to process
+
+    .PARAMETER Name
+        Name of the IIS AppPool
+
+    .PARAMETER Enable32Bit
+        Set this parameter to True if you want to run a 32Bit App on a 64Bit IIS        
+
+    .PARAMETER StartMode
+        AlwaysRunning or OnDemand, Default: OnDemand
+
+        AlwaysRunning:  Specifies that the Windows Process Activation Service (WAS) will always start the application pool. 
+                        This behavior allows an application to load the operating environment before any serving any HTTP requests, 
+                        which reduces the start-up processing for initial HTTP requests for the application.
+
+        OnDemand:   Specifies that the Windows Process Activation Service (WAS) will start the application pool when an HTTP request 
+                    is made for an application that is hosted in the application pool. This behavior resembles the WAS behavior in 
+                    previous versions of IIS.
+
+    .PARAMETER ManagedRuntimeVersion
+        v1.1, v2.0 or v4.0, Default: None
+
+        Optional string attribute.
+        Specifies the .NET Framework version to be used by the application pool.
+
+    .PARAMETER IdleTimeout
+        One way to conserve system resources is to configure idle time-out settings for the worker processes in an 
+        application pool. When these settings are configured, a worker process will shut down after a specified period 
+        of inactivity. The default value for idle time-out is 20 minutes.
+        
+    .PARAMETER PeriodicRestartTime
+        The PeriodicRestartTime element contains configuration settings that allow you to control when an application pool is recycled.
+
+    .PARAMETER IdentityType
+        0 = LocalSystem, 1 = LocalService, 2 = NetworkService, 3 = SpecificUser, 4 = ApplicationPoolIdentity  
+
+    .PARAMETER User
+        User for the IdentityType SpecificUser
+
+    .PARAMETER Password
+        Password for the IdentityType SpecificUser
+        
+    .PARAMETER LoadUserProfile
+        Defines if the AppPool should load the user Profile or not     
+#>
+[cmdletbinding()]
+param (
+    [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [psobject[]]$Deployment,
+
+    [Parameter(Mandatory=$true, Position=1)]
+    [string]$Name                  = $null,
+        
+    [bool]  $Enable32Bit           = $false,
+        
+    [string]$StartMode             = $null, 
+    [string]$ManagedRuntimeVersion = $null,
+    [string]$IdleTimeout           = $null,
+    [string]$PeriodicRestartTime   = $null,
+
+            $IdentityType          = $null,
+    [string]$User                  = $null,
+    [string]$Password              = $null,
+    [bool]  $LoadUserProfile       = $true
+)
+
+<#
+    Create an application pool an set the configuration.
+#>
+function Create-IISApplicationPool
+{
+    param(
+        # Application Pool Settings
+        [Parameter(Mandatory=$true, Position=1)]
+        [string]$name                  = $null,
+        
+        [bool]  $enable32Bit           = $false,
+        
+        [string]$startMode             = $null, # AlwaysRunning, 
+        [string]$managedRuntimeVersion = $null,
+        [string]$idleTimeout           = $null,
+        [string]$periodicRestartTime   = $null,
+        
+                $identityType          = $null,
+        [string]$user                  = $null,
+        [string]$password              = $null,
+        [bool]  $loadUserProfile       = $true
+    )
+    
+    begin
+    {
+        # IIS Directory Settings
+        [string]$iisPool = "IIS:\AppPools\$($name)\"
+        
+        # Sets the application pool settings for the given parameter
+        function Set-AppPoolProperties([PSObject]$pool)
+        {
+            if(-not $pool) { throw "Empty application pool, Argument -Pool is missing" }
+            
+            Write-Verbose "Configuring ApplicationPool properties"
+            
+            if ($startMode            ) { $pool.startMode                      = $startMode             }
+            if ($managedRuntimeVersion) { $pool.managedRuntimeVersion          = $managedRuntimeVersion }
+            if ($idleTimeout          ) { $pool.processModel.idleTimeout       = $idleTimeout           }
+            if ($periodicRestartTime  ) { $pool.recycling.periodicRestart.time = $periodicRestartTime   }
+            
+            if ($identityType -ne $null)
+            { 
+                $pool.processModel.identityType = $identityType
+                
+                if($identityType -eq 3) # 3 = SpecificUser
+                {
+                    if(-not $user    ) { throw "Empty user name, Argument -User is missing"  }
+                    if(-not $password) { throw "Empty password, Argument -Password is missing" }
+                    
+                    Write-Verbose "Setting AppPool to run as $user"
+                    
+                    $pool.processmodel.username = $user
+                    $pool.processmodel.password = $password
+                }
+            }
+            
+            $pool.processModel.loadUserProfile = $loadUserProfile
+            
+            $pool | Set-Item
+            
+            if($enable32Bit)
+            {
+                Set-ItemProperty $iisPool -Name enable32BitAppOnWin64 -Value "True"
+            }
+            else
+            {
+                Set-ItemProperty $iisPool -Name enable32BitAppOnWin64 -Value "False"
+            }
+        }
+    }
+    
+    process
+    {
+        Write-Verbose "Creating IIS ApplicationPool: $name"
+        
+        $pool = New-WebAppPool $name 
+        
+        Set-AppPoolProperties $pool
+    }
+    
+    End {}
+}
+
+<#
+    Removes the IIS application pool for the given name.
+#>
+function Remove-IISApplicationPool
+{
+    param(        
+        # Application Pool Settings
+        [Parameter(Mandatory=$true, Position=1)]
+        [string]$name = $null
+    )
+    
+    begin
+    {
+        # IIS Directory Settings
+        [string]$iisPoolPath = "IIS:\AppPools\$($name)\"
+    }
+    
+    process
+    {
+        if(Test-Path $iisPoolPath)
+        {
+            Write-Verbose "Removing Application Pool: $name"
+            
+            Stop-IISAppPool $name
+            
+            Remove-WebAppPool $name
+        }
+    }
+    
+    End {}
+}
+
+<#
+    Stop the AppPool if it exists and is running, and throws no error if it doesn't.
+#>
+function Stop-IISAppPool
+{
+    param(
+        # Application Pool Settings
+        [Parameter(Mandatory=$true, Position=1)]
+        [string]$name  = $null,
+        [bool]  $sleep = $false # seconds
+    )
+    
+    begin
+    {
+        # IIS Directory Settings
+        [string]$iisPoolPath = "IIS:\AppPools\$($name)\"
+    }
+    
+    process
+    {
+        Write-Verbose "Trying to stop the AppPool: $name"
+        
+        if (Test-Path $iisPoolPath)
+        {
+            if ((Get-WebAppPoolState -Name $name).Value -ne "Stopped")
+            {
+                Stop-WebAppPool -Name $name
+                
+                if (-not [string]::IsNullOrWhiteSpace($sleep))
+                {
+                    Start-Sleep -s $sleep
+                }
+                
+                Write-Verbose "Stopped AppPool: $name"
+            }
+            else 
+            {
+                Write-Verbose "WARNING: AppPool $name was already stopped. Have you already run this?"
+            }
+        }
+        else
+        {
+            Write-Verbose "WARNING: Could not find an AppPool called: $name to stop. Assuming this is a new installation."
+        }
+    }
+    
+    End {}
+}
+
+foreach($site in $Deployment)
+{
+    if (!(Get-Module WebAdministration))
+    {
+        ## Load it nested, and we'll automatically remove it during clean up.
+        Import-Module WebAdministration -ErrorAction Stop
+        Sleep 2 #see http://stackoverflow.com/questions/14862854/powershell-command-get-childitem-iis-sites-causes-an-error
+    }
+
+    Remove-IISApplicationPool -name $Name
+    Create-IISApplicationPool -name $Name `
+                                -enable32Bit $Enable32Bit `
+                                -startMode $StartMode `
+                                -managedRuntimeVersion $ManagedRuntimeVersion `
+                                -identityType $IdentityType `
+                                -idleTimeout $IdleTimeout `
+                                -periodicRestartTime $PeriodicRestartTime `
+                                -user $User `
+                                -password $Password `
+                                -loadUserProfile $LoadUserProfile
+}

--- a/PSDeploy/PSDeployScripts/IISSite.ps1
+++ b/PSDeploy/PSDeployScripts/IISSite.ps1
@@ -108,14 +108,6 @@ function Remove-IISWebsite
             
             Remove-Website $name
         }
-        
-        # Remove Website files
-        if(Test-Path $root)
-        {
-            Write-Verbose "Removing IIS Website root directory: $root"
-            
-            Remove-Item $root -Recurse -Force
-        }
     }
     
     End {}
@@ -124,19 +116,15 @@ function Remove-IISWebsite
 
 foreach($site in $Deployment)
 {
-    if($site.SourceExists)
+    if (!(Get-Module WebAdministration))
     {
-        if (!(Get-Module WebAdministration))
-        {
-            ## Load it nested, and we'll automatically remove it during clean up.
-            Import-Module WebAdministration -ErrorAction Stop
-            Sleep 2 #see http://stackoverflow.com/questions/14862854/powershell-command-get-childitem-iis-sites-causes-an-error
-        }
-
-        $root = $site.Targets[0]
-        Remove-IISWebsite -name $name -root $root
-        $ScriptPath = Split-Path -Path $MyInvocation.MyCommand.Path
-        & "$ScriptPath\FileSystem.ps1" -Deployment $Deployment
-        Create-IISWebsite -name $name -root $root -bindings $bindings        
+        ## Load it nested, and we'll automatically remove it during clean up.
+        Import-Module WebAdministration -ErrorAction Stop
+        Sleep 2 #see http://stackoverflow.com/questions/14862854/powershell-command-get-childitem-iis-sites-causes-an-error
     }
+    # TODO: Multiple Targets
+    # TODO: Remote Machines
+    $root = $site.Targets[0]
+    Remove-IISWebsite -name $name -root $root
+    Create-IISWebsite -name $name -root $root -bindings $bindings
 }

--- a/PSDeploy/PSDeployScripts/IISSite.ps1
+++ b/PSDeploy/PSDeployScripts/IISSite.ps1
@@ -1,34 +1,49 @@
 <#
     .SYNOPSIS
-        Support deployments by handling simple tasks.
+        Deploys an IISSite using Powershell
 
     .DESCRIPTION
-        Support deployments by handling simple tasks.
-
-        You can use a Task in two ways:
-
-        As a scriptblock:
-
-            By Task {
-                "Run some deployment code in this scriptblock!"
+        Deploys an IISSite using Powershell
+    
+        By IISSite MyWebsite {
+            To .\wwwroot
+            WithOptions @{
+                name = "SiteName"
+                bindings = @(
+                    @{protocol="http"; bindingInformation="*:80:www.myurl.com" }
+                    @{protocol="https"; bindingInformation="*:443:www.myurl.com" }
+                    )
             }
+        }
 
-        As a script:
-
-            By Task {
-                FromSource "Path\To\SomeDeploymentScript.ps1"
-            }
+        To: Is the root path of the Website to deploy using IIS, currently only one target is supported
 
     .PARAMETER Deployment
         Deployment to process
+
+    .PARAMETER Name
+        Name of the Site under which it will be listed in IIS
+
+    .PARAMETER AppPool
+        AppPool to be used for this site in IIS, will be created if it does not exist. But it is recommend to use the extra 
+        Deployment Type IISAppPool to setup a AppPool with specific settings.
+
+    .PARAMETER Bindings
+        Bindings under which this Site should be reachable
 #>
 [cmdletbinding()]
 param (
     [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
     [psobject[]]$Deployment,
-    [string]  $name     = $null,    
-    [string]  $appPool  = "DefaultAppPool",
-    [Object[]]$bindings = $null
+
+    [Parameter(Mandatory=$true, Position=1)]
+    [string]  $Name     = $null,    
+
+    [Parameter(Mandatory=$false, Position=2)]
+    [string]  $AppPool  = "DefaultAppPool",
+
+    [Parameter(Mandatory=$false, Position=3)]
+    [Object[]]$Bindings = $null
 )
 
 <#
@@ -37,21 +52,18 @@ param (
 function Create-IISWebsite
 {
     param(
+        [Parameter(Mandatory=$true, Position=1)]
         [string]  $name     = $null,
+
+        [Parameter(Mandatory=$true, Position=2)]
         [string]  $root     = $null,
+
         [string]  $appPool  = "DefaultAppPool",
         [Object[]]$bindings = $null
     )
     
     begin
     {
-    
-        if(-not $name) { throw "Empty site name, Argument -Name is missing"        }
-        if(-not $root) { throw "Empty website root path, Argument -Root is missing"}
-        
-        
-        # SETTINGS
-        
         # IIS Directory Settings
         [string]$iisSite = "IIS:\Sites\$($name)\"
     }
@@ -81,20 +93,16 @@ function Create-IISWebsite
 #>
 function Remove-IISWebsite
 {
-    param(        
-        # Website Settings
+    param(                
+        [Parameter(Mandatory=$true, Position=1)]
         [string]$name    = $null,
+
+        [Parameter(Mandatory=$true, Position=2)]
         [string]$root    = $null
     )
     
     begin
     {
-        if(-not $name) { throw "Empty site name, Argument -Name is missing"        }
-        if(-not $root) { throw "Empty website root path, Argument -Root is missing"}
-        
-        
-        # SETTINGS
-        
         # IIS Directory Settings
         [string]$iisSite = "IIS:\Sites\$($name)"
     }
@@ -122,9 +130,18 @@ foreach($site in $Deployment)
         Import-Module WebAdministration -ErrorAction Stop
         Sleep 2 #see http://stackoverflow.com/questions/14862854/powershell-command-get-childitem-iis-sites-causes-an-error
     }
-    # TODO: Multiple Targets
-    # TODO: Remote Machines
+
+    [string]$iisPoolPath = "IIS:\AppPools\$($AppPool)\"
+
+    if(!(Test-Path $iisPoolPath))
+    {
+        Write-Verbose "AppPool $name does not exist, it will be created with default settings. For special settings please use IISAppPool as individual Deployment Type"
+        # Workaround to call the IISAppPool creation from within this Deployment type $Deployment is forwarded but not processed.
+        . $PSScriptRoot\IISAppPool.ps1 -Deployment $Deployment -Name $AppPool
+    }
+
     $root = $site.Targets[0]
-    Remove-IISWebsite -name $name -root $root
-    Create-IISWebsite -name $name -root $root -bindings $bindings
+
+    Remove-IISWebsite -name $Name -root $root
+    Create-IISWebsite -name $Name -root $root -bindings $Bindings -appPool $AppPool
 }

--- a/PSDeploy/PSDeployScripts/IISSite.ps1
+++ b/PSDeploy/PSDeployScripts/IISSite.ps1
@@ -1,0 +1,142 @@
+<#
+    .SYNOPSIS
+        Support deployments by handling simple tasks.
+
+    .DESCRIPTION
+        Support deployments by handling simple tasks.
+
+        You can use a Task in two ways:
+
+        As a scriptblock:
+
+            By Task {
+                "Run some deployment code in this scriptblock!"
+            }
+
+        As a script:
+
+            By Task {
+                FromSource "Path\To\SomeDeploymentScript.ps1"
+            }
+
+    .PARAMETER Deployment
+        Deployment to process
+#>
+[cmdletbinding()]
+param (
+    [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [psobject[]]$Deployment,
+    [string]  $name     = $null,    
+    [string]  $appPool  = "DefaultAppPool",
+    [Object[]]$bindings = $null
+)
+
+<#
+    Creates an IIS website and sets the configuration
+#>
+function Create-IISWebsite
+{
+    param(
+        [string]  $name     = $null,
+        [string]  $root     = $null,
+        [string]  $appPool  = "DefaultAppPool",
+        [Object[]]$bindings = $null
+    )
+    
+    begin
+    {
+    
+        if(-not $name) { throw "Empty site name, Argument -Name is missing"        }
+        if(-not $root) { throw "Empty website root path, Argument -Root is missing"}
+        
+        
+        # SETTINGS
+        
+        # IIS Directory Settings
+        [string]$iisSite = "IIS:\Sites\$($name)\"
+    }
+    
+    process
+    {
+        Write-Verbose "Creating IIS Website: $name"
+        
+        if($bindings -ne $null)
+        {
+            New-Item $iisSite -Type Site -Bindings $bindings -PhysicalPath $root
+        }
+        else
+        {
+            New-Item $iisSite -Type Site -PhysicalPath $root
+        }
+        
+        Set-ItemProperty $iisSite -Name ApplicationPool -Value $appPool
+    }
+    
+    End {}
+}
+
+<#
+    Removes the IIS Website installation for the given site name.
+    The application pool gets only removed if the -appPoolName parameter is supplied.
+#>
+function Remove-IISWebsite
+{
+    param(        
+        # Website Settings
+        [string]$name    = $null,
+        [string]$root    = $null
+    )
+    
+    begin
+    {
+        if(-not $name) { throw "Empty site name, Argument -Name is missing"        }
+        if(-not $root) { throw "Empty website root path, Argument -Root is missing"}
+        
+        
+        # SETTINGS
+        
+        # IIS Directory Settings
+        [string]$iisSite = "IIS:\Sites\$($name)"
+    }
+    
+    process
+    {
+        # Remove Website
+        if(Test-Path $iisSite)
+        {
+            Write-Verbose "Deleting IIS Website: $name"
+            
+            Remove-Website $name
+        }
+        
+        # Remove Website files
+        if(Test-Path $root)
+        {
+            Write-Verbose "Removing IIS Website root directory: $root"
+            
+            Remove-Item $root -Recurse -Force
+        }
+    }
+    
+    End {}
+}
+
+
+foreach($site in $Deployment)
+{
+    if($site.SourceExists)
+    {
+        if (!(Get-Module WebAdministration))
+        {
+            ## Load it nested, and we'll automatically remove it during clean up.
+            Import-Module WebAdministration -ErrorAction Stop
+            Sleep 2 #see http://stackoverflow.com/questions/14862854/powershell-command-get-childitem-iis-sites-causes-an-error
+        }
+
+        $root = $site.Targets[0]
+        Remove-IISWebsite -name $name -root $root
+        $ScriptPath = Split-Path -Path $MyInvocation.MyCommand.Path
+        & "$ScriptPath\FileSystem.ps1" -Deployment $Deployment
+        Create-IISWebsite -name $name -root $root -bindings $bindings        
+    }
+}

--- a/PSDeploy/PSDeployScripts/NSSM.ps1
+++ b/PSDeploy/PSDeployScripts/NSSM.ps1
@@ -57,7 +57,7 @@ param (
     [string]  $ServiceArgs     = $null,
 
     [Parameter(Mandatory=$true, Position=5)]
-    [string]  $NSSMBinaryPath     = $null
+    [string]  $NSSMBinaryPath     = $null,
 
     [Parameter(Mandatory=$false, Position=6)]
     [bool]  $StartService     = $true

--- a/PSDeploy/PSDeployScripts/Node.ps1
+++ b/PSDeploy/PSDeployScripts/Node.ps1
@@ -1,0 +1,198 @@
+<#
+    .SYNOPSIS
+        Support deployments by handling simple tasks.
+
+    .DESCRIPTION
+        Support deployments by handling simple tasks.
+
+        You can use a Task in two ways:
+
+        As a scriptblock:
+
+            By Task {
+                "Run some deployment code in this scriptblock!"
+            }
+
+        As a script:
+
+            By Task {
+                FromSource "Path\To\SomeDeploymentScript.ps1"
+            }
+
+    .PARAMETER Deployment
+        Deployment to process
+#>
+[cmdletbinding()]
+param (
+    [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [psobject[]]$Deployment,
+
+    [Parameter(Mandatory=$true, Position=1)]
+    [string]  $ServiceName     = $null,
+
+    [Parameter(Mandatory=$true, Position=2)]
+    [string]  $ServiceBinaryPath     = $null,
+
+    [Parameter(Mandatory=$false, Position=3)]
+    [string]  $AppDirectory     = $null,
+
+    [Parameter(Mandatory=$true, Position=4)]
+    [string]  $ServiceArgs     = $null,
+
+    [Parameter(Mandatory=$true, Position=5)]
+    [string]  $NSSMBinaryPath     = $null
+)
+
+<#
+    Creates an Non-Sucking Service Manager Service
+#>
+function Create-NSSMService
+{
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [string]  $ServiceName     = $null,
+
+        [Parameter(Mandatory=$true, Position=2)]
+        [string]  $ServiceBinaryPath     = $null,
+
+        [Parameter(Mandatory=$true, Position=3)]
+        [string]  $ServiceArgs     = $null,
+
+        [Parameter(Mandatory=$true, Position=4)]
+        [string]  $NSSMBinaryPath     = $null
+    )
+    
+    begin
+    {
+    }
+    
+    process
+    {
+        Write-Verbose "Creating Service $ServiceName"
+        Start-Process -FilePath $NSSMBinaryPath -Args "install $ServiceName $ServiceBinaryPath $ServiceArgs" -Verb runAs -Wait
+        Write-Verbose "Service $ServiceName created"
+    }
+    
+    End {}
+}
+
+<#
+    Removes an Non-Sucking Service Manager Service
+#>
+function Remove-NSSMService
+{
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [string]  $ServiceName     = $null,
+
+        [Parameter(Mandatory=$true, Position=2)]
+        [string]  $NSSMBinaryPath     = $null
+    )
+    
+    begin
+    {
+    }
+    
+    process
+    {
+        Write-Verbose "Removing Service $ServiceName"
+        Start-Process -FilePath $NSSMBinaryPath -Args "remove $ServiceName confirm" -Verb runAs -Wait
+        Write-Verbose "Service $ServiceName removed"
+    }
+    
+    End {}
+}
+
+<#
+    Set Non-Sucking Service Manager Parameter AppDirectory
+#>
+function Set-NSSM-AppDirectory
+{
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [string]  $ServiceName     = $null,
+
+        [Parameter(Mandatory=$true, Position=2)]
+        [string]  $AppDirectory     = $null,
+
+        [Parameter(Mandatory=$true, Position=3)]
+        [string]  $NSSMBinaryPath     = $null
+    )
+    
+    begin
+    {
+    }
+    
+    process
+    {
+        Write-Verbose "Set NSSM-AppDirectory $AppDirectory on Service $ServiceName"
+        Start-Process -FilePath $NSSMBinaryPath -Args "set $ServiceName AppDirectory $AppDirectory" -Verb runAs -Wait        
+    }
+    
+    End {}
+}
+
+<#
+    Starts an Non-Sucking Service Manager Service
+#>
+function Start-NSSMService
+{
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [string]  $ServiceName     = $null,
+
+        [Parameter(Mandatory=$true, Position=2)]
+        [string]  $NSSMBinaryPath     = $null
+    )
+    
+    begin
+    {
+    }
+    
+    process
+    {
+        Write-Verbose "Starting Service $ServiceName"
+        Start-Process -FilePath $NSSMBinaryPath -Args "start $ServiceName" -Verb runAs -Wait
+        Write-Verbose "Service $ServiceName started"
+    }
+    
+    End {}
+}
+
+<#
+    Stops an Non-Sucking Service Manager Service
+#>
+function Stop-NSSMService
+{
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [string]  $ServiceName     = $null,
+
+        [Parameter(Mandatory=$true, Position=2)]
+        [string]  $NSSMBinaryPath     = $null
+    )
+    
+    begin
+    {
+    }
+    
+    process
+    {
+        Write-Verbose "Stopping Service $ServiceName"
+        Start-Process -FilePath $NSSMBinaryPath -Args "stop $ServiceName" -Verb runAs -Wait
+        Write-Verbose "Service $ServiceName stopped"
+    }
+    
+    End {}
+}
+
+foreach($site in $Deployment)
+{
+    Stop-NSSMService -ServiceName $ServiceName -NSSMBinaryPath $NSSMBinaryPath
+    Remove-NSSMService -ServiceName $ServiceName -NSSMBinaryPath $NSSMBinaryPath
+    Create-NSSMService -ServiceName $ServiceName -ServiceBinaryPath $ServiceBinaryPath -ServiceArgs $ServiceArgs -NSSMBinaryPath $NSSMBinaryPath
+    if($AppDirectory) {
+        Set-NSSM-AppDirectory -ServiceName $ServiceName -AppDirectory $AppDirectory -NSSMBinaryPath $NSSMBinaryPath    
+    }    
+    Start-NSSMService -ServiceName $ServiceName -NSSMBinaryPath $NSSMBinaryPath
+}

--- a/PSDeploy/PSDeployScripts/Node.ps1
+++ b/PSDeploy/PSDeployScripts/Node.ps1
@@ -188,11 +188,11 @@ function Stop-NSSMService
 
 foreach($site in $Deployment)
 {
-    Stop-NSSMService -ServiceName $ServiceName -NSSMBinaryPath $NSSMBinaryPath
+    # Stop-NSSMService -ServiceName $ServiceName -NSSMBinaryPath $NSSMBinaryPath
     Remove-NSSMService -ServiceName $ServiceName -NSSMBinaryPath $NSSMBinaryPath
     Create-NSSMService -ServiceName $ServiceName -ServiceBinaryPath $ServiceBinaryPath -ServiceArgs $ServiceArgs -NSSMBinaryPath $NSSMBinaryPath
     if($AppDirectory) {
         Set-NSSM-AppDirectory -ServiceName $ServiceName -AppDirectory $AppDirectory -NSSMBinaryPath $NSSMBinaryPath    
     }    
-    Start-NSSMService -ServiceName $ServiceName -NSSMBinaryPath $NSSMBinaryPath
+    # Start-NSSMService -ServiceName $ServiceName -NSSMBinaryPath $NSSMBinaryPath
 }

--- a/PSDeploy/Private/Resolve-DeployScripts.ps1
+++ b/PSDeploy/Private/Resolve-DeployScripts.ps1
@@ -35,7 +35,7 @@ function Resolve-DeployScripts
                 Resolve-Path -Path $unresolvedPath |
                     Where-Object { $_.Provider.Name -eq 'FileSystem' } |
                     Select-Object -ExpandProperty ProviderPath |
-                    Get-ChildItem -Filter *PSDeploy.ps1 @RecurseParam |
+                    Get-ChildItem -Filter *.*deploy.ps1 @RecurseParam |
                     Where-Object { -not $_.PSIsContainer } |
                     Select-Object -ExpandProperty FullName -Unique
             }

--- a/PSDeploy/Public/Get-PSDeployment.ps1
+++ b/PSDeploy/Public/Get-PSDeployment.ps1
@@ -209,7 +209,7 @@
         {
             # TODO: This should be abstracted out, and use the same code that file parameterset uses...
             $Sources = @($DeploymentItem.Source)
-
+            
             #TODO: Move this, not applicable to all deployment types
             foreach($Source in $Sources)
             {
@@ -217,7 +217,7 @@
                 $Exists = $null
                 $Type = $null
 
-                if(-not ($DeploymentItem.DeploymentType -eq 'Task' -and $Source -is [scriptblock]))
+                if(-not ($DeploymentItem.DeploymentType -eq 'Task' -and $Source -is [scriptblock]) -and ($Source))
                 {
                     #Determine the path to this source. Try absolute, fall back on relative
                     if((Test-Path $Source -ErrorAction SilentlyContinue) -or $DeploymentItem.DeploymentOptions.SourceIsAbsolute)


### PR DESCRIPTION
I think i have everything needed in regards to functionality. May you can already have a look at it and double check if some changes to the existing codes are not ok. I will try to create some tests the next days. 

Please also note that I changed the filter that a file called .deploy.ps1 will be detected by Invoke-PSDeploy. Our project structure is like that why i thought it is handy to call our deploy files .deploy.ps1

\
    \src
    \node_module
    \many_more...
    .build.ps1
    .deploy.ps1
    build.ps1
    install.ps1

We do use Invoke-Build for builds and that usually copies build results to a .\setup folder including the .deploy.ps1 and install.ps1, our install.ps1 then calls the installation process and sets enviroment variables which are later on picked up by PSDeploy. 

I will try to write that down in more detailed at some point and will provide a pull request then as I think the documentation of PSDeploy needs more details at some point. 