### PR TITLE
Remove /xo argument from robocopy filesystem deployments

### DIFF
--- a/PSDeploy/PSDeployScripts/FileSystem.ps1
+++ b/PSDeploy/PSDeployScripts/FileSystem.ps1
@@ -33,8 +33,7 @@ foreach($Map in $Deployment)
         {
             if($Map.SourceType -eq 'Directory')
             {
-                [string[]]$Arguments = "/XO"
-                $Arguments += "/E"
+                [string[]]$Arguments = "/E"
                 if($Map.DeploymentOptions.mirror -eq 'True' -or $Mirror)
                 {
                     $Arguments += "/PURGE"

--- a/PSDeploy/PSDeployScripts/FilesystemRemote.ps1
+++ b/PSDeploy/PSDeployScripts/FilesystemRemote.ps1
@@ -99,8 +99,7 @@ Invoke-Command @PSBoundParameters -ScriptBlock {
             {
                 if($Map.SourceType -eq 'Directory')
                 {
-                    [string[]]$Arguments = "/XO"
-                    $Arguments += "/E"
+                    [string[]]$Arguments = "/E"
                     if($Map.DeploymentOptions.mirror -eq 'True' -or $Using:Mirror)
                     {
                         $Arguments += "/PURGE"


### PR DESCRIPTION
Hello,

The expected behavior from Robocopy mirror deployments is to mirror the source DIR to the destination but i found that if files are updated in the source, they aren't replaced. This is due to the /xo flag. I tested without this and confirmed any changes in destination are replaced with files from source once this is removed.

This ensures staff are not updating PROD and PROD will always mirror our source git repository when using psdeploy.

Robocopy /?
/XO : eXclude Older - if destination file exists and is the same date
                     or newer than the source - don’t bother to overwrite it.