### PR TITLE
Modified nuspec and nupkg references to be OS agnostic

### DIFF
--- a/PSDeploy/PSDeployScripts/AppVeyorModule.ps1
+++ b/PSDeploy/PSDeployScripts/AppVeyorModule.ps1
@@ -272,8 +272,8 @@ foreach($Deploy in $Deployment) {
     
         New-Nuspec @NuSpecParams
         $StagingParentPath = (Split-Path -parent $StagingDirectory)
-        $null = nuget pack "$StagingDirectory\$ModuleName.nuspec" -outputdirectory $StagingParentPath
-        $NuGetPackagePath = "$StagingParentPath\$ModuleName.$Version.nupkg"
+        $null = nuget pack (Join-Path $StagingDirectory "$ModuleName.nuspec") -outputdirectory $StagingParentPath
+        $NuGetPackagePath = (Join-Path $StagingParentPath "$ModuleName.$Version.nupkg")
 
         $ZipFilePath,
         $nuGetPackagePath | % {


### PR DESCRIPTION
The current code fails on Ubuntu under PowerShell Core because the path references to the .nupkg file include a backslash. This commit changes the code so the path is constructed via `Join-Path` instead.