### PR TITLE
Changed PSYaml support module to use OS specific Temp folder as Default - Fixes #113

### DIFF
--- a/PSDeploy/Private/PSYaml/Private/Get-TempPath.ps1
+++ b/PSDeploy/Private/PSYaml/Private/Get-TempPath.ps1
@@ -1,0 +1,18 @@
+<#
+    .SYNOPSIS
+        Return the OS specific temp folder path.
+#>
+function Get-TempPath() {
+    if($ENV:Temp) {
+        # Windows Temp Folder Location
+        return $ENV:Temp
+    }
+    elseif ($env:TMPDIR) {
+        # macOS Temp Folder Location
+        return $ENV:TMPDIR
+    }
+    else {
+        # Linux Temp Folder Location
+        return '/tmp'
+    }
+}

--- a/PSDeploy/Private/PSYaml/Private/Shadow-Copy.ps1
+++ b/PSDeploy/Private/PSYaml/Private/Shadow-Copy.ps1
@@ -1,4 +1,4 @@
-function Shadow-Copy($file, $shadowPath = "$($env:TEMP)\poweryaml\shadow") {
+function Shadow-Copy($file, $shadowPath = (Join-Path -Path (Get-TempPath) -ChildPath 'poweryaml\shadow')) {
 
     if(!(Test-Path -Path Variable:\IsWindows) -or $IsWindows) {
         if (-not (Test-Path $shadowPath ) ) {

--- a/PSDeploy/Private/PSYaml/Private/YamlDotNet-Integration.ps1
+++ b/PSDeploy/Private/PSYaml/Private/YamlDotNet-Integration.ps1
@@ -1,4 +1,4 @@
-function Load-YamlDotNetLibraries([string] $dllPath, $shadowPath = "$($env:TEMP)\poweryaml\shadow") {
+function Load-YamlDotNetLibraries([string] $dllPath, $shadowPath = (Join-Path -Path (Get-TempPath) -ChildPath 'poweryaml\shadow')) {
     gci $dllPath | % {
         $shadow = Shadow-Copy -File $_.FullName -ShadowPath $shadowPath
         Add-Type -Path $Shadow
@@ -42,14 +42,14 @@ function Convert-YamlScalarNodeToValue {
 
 function Convert-YamlMappingNodeToHash {
     param($node, $As)
-    
+
     $hash = @{}
 
     if($ModernPS -and $As -eq 'Object')
     {
         $hash = [ordered]@{}
     }
-    
+
     $yamlNodes = $node.Children
 
     foreach($key in $yamlNodes.Keys)


### PR DESCRIPTION
This PR changes the temporary folder location that the support module PSYaml copies the `YamlDotNet.dll` file to. It will use the default folder location specific to the OS:
- Windows: $ENV:Temp
- macOS: $ENV:TMPDIR
- Linux: /tmp

This is to ensure that if the `YamlDotNet.dll` is copied within the `Shadow-Copy` function it will be copied to the Temp folder specific to the OS type.

However, it does seem that the `Shadow-Copy` should not copy this file at all for non-Windows OS's. But evidence from `TravisCI` and `Azure Pipelines` shows that this check fails on non-Windows OS's for those build machines and still attempts to copy the file.

I am not certain of the cause of this issue, but I thought the better approach was to just ensure the shadow copy worked correctly no matter which OS was running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramblingcookiemonster/psdeploy/116)
<!-- Reviewable:end -->
