### PR TITLE
Change ApiKey param to optional

### DIFF
--- a/PSDeploy/PSDeployScripts/PSGalleryScript.ps1
+++ b/PSDeploy/PSDeployScripts/PSGalleryScript.ps1
@@ -85,7 +85,7 @@ param(
     [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
     [psobject[]]$Deployment,
 
-    [Parameter(Mandatory)]
+    [Parameter(Mandatory=$false)]
     [string]$ApiKey
 )
 


### PR DESCRIPTION
This was changed in the PSGalleryModule.ps1 script, and should be changed here too for similar reasons. I often deploy scripts to a simple repo that is internal and does not need an API key.