### PR TITLE
Support loading custom PSDeploy.yaml scripts

### DIFF
--- a/PSDeploy/Public/Get-PSDeploymentScript.ps1
+++ b/PSDeploy/Public/Get-PSDeploymentScript.ps1
@@ -58,6 +58,7 @@
 
     # Abstract out reading the yaml and verifying scripts exist
     $DeploymentDefinitions = ConvertFrom-Yaml -Path $Path
+    $DefinitionPath = Split-Path $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path) -Parent
 
     $DeployHash = @{}
     foreach($DeploymentType in $DeploymentDefinitions.Keys)
@@ -70,8 +71,14 @@
         }
         else
         {
-            # account for missing ps1
-            $ScriptPath = Join-Path $ModulePath "PSDeployScripts\$($Script -replace ".ps1$").ps1"
+            # Search in the module's installed path as well as the PSDeploy.yml path if a custom one was defined
+            foreach ($p in @($ModulePath, $DefinitionPath | Select-Object -Unique)) {
+                # account for missing ps1
+                $ScriptPath = [System.IO.Path]::Combine($p, "PSDeployScripts", $Script -replace ".ps1$") + ".ps1"
+                if (Test-Path $ScriptPath) {
+                    break
+                }
+            }
         }
 
         if(test-path $ScriptPath)

--- a/PSDeploy/Public/Invoke-PSDeploy.ps1
+++ b/PSDeploy/Public/Invoke-PSDeploy.ps1
@@ -199,7 +199,7 @@
             $GetPSDeployParams.Add('DeploymentRoot', $DeploymentRoot)
         }
 
-        $DeploymentScripts = Get-PSDeploymentScript
+        $DeploymentScripts = Get-PSDeploymentScript -Path $PSDeployTypePath
 
         # Handle Dependencies
         $ToDeploy = Get-PSDeployment @GetPSDeployParams

--- a/PSDeploy/Public/Invoke-PSDeployment.ps1
+++ b/PSDeploy/Public/Invoke-PSDeployment.ps1
@@ -154,7 +154,7 @@
                                     "Processing deployment" ))
         {
             #Get definitions, and deployments in this particular yml
-            $DeploymentDefs = Get-PSDeploymentScript
+            $DeploymentDefs = Get-PSDeploymentScript -Path $PSDeployTypePath
             $TheseDeploymentTypes = @( $Deployment.DeploymentType | Sort-Object -Unique )
 
             #Build up hash, we call each deploymenttype script for applicable deployments

--- a/Tests/Get-PSDeploymentScript.Tests.ps1
+++ b/Tests/Get-PSDeploymentScript.Tests.ps1
@@ -80,13 +80,13 @@ Param (
 
             $DeploymentScripts = Get-PSDeploymentScript -Path $TestPath @Verbose
             It 'Should have returned only 1 script' {
-                $DeploymentScripts.Count | Should -Be 1
+                $DeploymentScripts.Count | Should be 1
             }
 
             foreach ($DeploymentScript in $DeploymentScripts.GetEnumerator())
             {
                 It "[$($DeploymentScript.Name)] should point to custom dir" {
-                    $DeploymentScript.value | Should -Be (Get-Item -Path $ScriptPath).FullName
+                    $DeploymentScript.value | Should be (Get-Item -Path $ScriptPath).FullName
                 }
             }
         }
@@ -120,13 +120,13 @@ Param (
 
             $DeploymentScripts = Get-PSDeploymentScript -Path $TestPath @Verbose
             It 'Should have returned only 1 script' {
-                $DeploymentScripts.Count | Should -Be 1
+                $DeploymentScripts.Count | Should be 1
             }
 
             foreach ($DeploymentScript in $DeploymentScripts.GetEnumerator())
             {
                 It "[$($DeploymentScript.Name)] Should use module path" {
-                    $DeploymentScript.value | Should -Be ([System.IO.Path]::Combine($ProjectRoot, $ModuleName, 'PSDeployScripts', 'Filesystem.ps1'))
+                    $DeploymentScript.value | Should be ([System.IO.Path]::Combine($ProjectRoot, $ModuleName, 'PSDeployScripts', 'Filesystem.ps1'))
                 }
             }
         }

--- a/Tests/Get-PSDeploymentScript.Tests.ps1
+++ b/Tests/Get-PSDeploymentScript.Tests.ps1
@@ -55,5 +55,80 @@ PlatyPS:
                 $DeploymentScripts.count | Should be $ScriptTypes.count
             }
         }
+
+        Context 'Deployment Script should be looked up in PSDeploy.yml path' {
+            $TestPath = Join-Path -Path 'TestDrive:\' -ChildPath 'PSDeploy.yml'
+            $FakeYml | Out-File -FilePath $TestPath -Force
+            $ScriptParentPath = Join-Path -Path 'TestDrive:\' -ChildPath 'PSDeployScripts'
+            $ScriptPath = Join-Path -Path $ScriptParentPath -ChildPath 'FakePlatyPS.ps1'
+            New-Item -Path $ScriptParentPath -ItemType Directory > $null
+            $FakeScript = @'
+[CmdletBinding()]
+Param (
+    [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [PSObject[]]$Deployment,
+
+    [Parameter(Mandatory=$true)]
+    [System.String]
+    $Option1,
+
+    [System.String]
+    $Option2,
+)
+'@
+            $FakeScript | Out-File -FilePath $ScriptPath -Force
+
+            $DeploymentScripts = Get-PSDeploymentScript -Path $TestPath @Verbose
+            It 'Should have returned only 1 script' {
+                $DeploymentScripts.Count | Should -Be 1
+            }
+
+            foreach ($DeploymentScript in $DeploymentScripts.GetEnumerator())
+            {
+                It "[$($DeploymentScript.Name)] should point to custom dir" {
+                    $DeploymentScript.value | Should -Be (Get-Item -Path $ScriptPath).FullName
+                }
+            }
+        }
+
+        Context 'Deployment Script should favour module install path over PSDeploy.yml path' {
+            $TestPath = Join-Path -Path 'TestDrive:\' -ChildPath 'PSDeploy.yml'
+            $NewYml = @'
+FileSystem:
+  Script: FileSystem.ps1
+  Description: Test description for filesystem
+'@
+            $NewYml | Out-File -FilePath $TestPath -Force
+            $ScriptParentPath = Join-Path -Path 'TestDrive:\' -ChildPath 'PSDeployScripts'
+            $ScriptPath = Join-Path -Path $ScriptParentPath -ChildPath 'FileSystem.ps1'
+            New-Item -Path $ScriptParentPath -ItemType Directory > $null
+            $FakeScript = @'
+[CmdletBinding()]
+Param (
+    [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [PSObject[]]$Deployment,
+
+    [Parameter(Mandatory=$true)]
+    [System.String]
+    $Option1,
+
+    [System.String]
+    $Option2,
+)
+'@
+            $FakeScript | Out-File -FilePath $ScriptPath -Force
+
+            $DeploymentScripts = Get-PSDeploymentScript -Path $TestPath @Verbose
+            It 'Should have returned only 1 script' {
+                $DeploymentScripts.Count | Should -Be 1
+            }
+
+            foreach ($DeploymentScript in $DeploymentScripts.GetEnumerator())
+            {
+                It "[$($DeploymentScript.Name)] Should use module path" {
+                    $DeploymentScript.value | Should -Be ([System.IO.Path]::Combine($ProjectRoot, $ModuleName, 'PSDeployScripts', 'Filesystem.ps1'))
+                }
+            }
+        }
     }
 }

--- a/Tests/Get-PSDeploymentType.Tests.ps1
+++ b/Tests/Get-PSDeploymentType.Tests.ps1
@@ -117,7 +117,7 @@ Param (
         $DeploymentTypes = Get-PSDeploymentType -Path $TestPath @Verbose
 
         It 'Deployment Types should only have 2 entries' {
-            $DeploymentTypes.Count | Should -Be 2
+            $DeploymentTypes.Count | Should Be 2
         }
 
         Context 'Deployment Types Should return valid paths' {
@@ -131,11 +131,11 @@ Param (
 
                 if ($DeploymentType.DeploymentType -eq 'FileSystem') {
                     It "[$($DeploymentType.DeploymentType)] Should be in module path" {
-                        $DeploymentType.DeploymentScript | Should -Be ([System.IO.Path]::Combine($ProjectRoot, $ModuleName, 'PSDeployScripts', 'FileSystem.ps1'))
+                        $DeploymentType.DeploymentScript | Should Be ([System.IO.Path]::Combine($ProjectRoot, $ModuleName, 'PSDeployScripts', 'FileSystem.ps1'))
                     }
                 } else {
                     It "[$($DeploymentType.DeploymentType)] Should be in custom path" {
-                        $DeploymentType.DeploymentScript | Should -Be (Get-Item -Path $CustomScriptPath).FullName
+                        $DeploymentType.DeploymentScript | Should Be (Get-Item -Path $CustomScriptPath).FullName
                     }
                 }
             }

--- a/Tests/Get-PSDeploymentType.Tests.ps1
+++ b/Tests/Get-PSDeploymentType.Tests.ps1
@@ -76,4 +76,79 @@ InModuleScope 'PSDeploy' {
             }
         }
     }
+
+    Describe "Get-PSDeploymentType -Path PS$PSVersion" {
+        # We aren't testing Get-Help and it takes time to run so just mock it out for this block
+        Mock Get-Help { return "" }
+
+        $TestPath = Join-Path -Path 'TestDrive:\' -ChildPath 'PSDeploy.yml'
+        $NewYml = @'
+FileSystem:
+  Script: FileSystem.ps1
+  Description: Test description for filesystem
+
+CustomType:
+  Script: CustomType.ps1
+  Description: Test description for custom type
+'@
+        $NewYml | Out-File -FilePath $TestPath -Force
+        $ScriptParentPath = Join-Path -Path 'TestDrive:\' -ChildPath 'PSDeployScripts'
+        $FSScriptPath = Join-Path -Path $ScriptParentPath -ChildPath 'FileSystem.ps1'
+        $CustomScriptPath = Join-Path -Path $ScriptParentPath -ChildPath 'CustomType.ps1'
+
+        New-Item -Path $ScriptParentPath -ItemType Directory > $null
+        $FakeScript = @'
+[CmdletBinding()]
+Param (
+    [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [PSObject[]]$Deployment,
+
+    [Parameter(Mandatory=$true)]
+    [System.String]
+    $Option1,
+
+    [System.String]
+    $Option2,
+)
+'@
+        $FakeScript | Out-File -FilePath $FSScriptPath -Force
+        $FakeScript | Out-File -FilePath $CustomScriptPath -Force
+
+        $DeploymentTypes = Get-PSDeploymentType -Path $TestPath @Verbose
+
+        It 'Deployment Types should only have 2 entries' {
+            $DeploymentTypes.Count | Should -Be 2
+        }
+
+        Context 'Deployment Types Should return valid paths' {
+
+            foreach ($DeploymentType in $DeploymentTypes.GetEnumerator())
+            {
+                It "[$($DeploymentType.DeploymentScript)] Should Exist" {
+                    $Results = Test-Path $DeploymentType.DeploymentScript
+                    $Results | Should be $True
+                }
+
+                if ($DeploymentType.DeploymentType -eq 'FileSystem') {
+                    It "[$($DeploymentType.DeploymentType)] Should be in module path" {
+                        $DeploymentType.DeploymentScript | Should -Be ([System.IO.Path]::Combine($ProjectRoot, $ModuleName, 'PSDeployScripts', 'FileSystem.ps1'))
+                    }
+                } else {
+                    It "[$($DeploymentType.DeploymentType)] Should be in custom path" {
+                        $DeploymentType.DeploymentScript | Should -Be (Get-Item -Path $CustomScriptPath).FullName
+                    }
+                }
+            }
+        }
+
+        Context 'Deployment Types Should have Description' {
+
+            foreach ($DeploymentType in $DeploymentTypes.GetEnumerator())
+            {
+                It "[$($DeploymentType.DeploymentType)] Should have a Description" {
+                    $DeploymentType.Description | Should Not BeNullOrEmpty
+                }
+            }
+        }
+    }
 }

--- a/Tests/Invoke-PSDeploy.Tests.ps1
+++ b/Tests/Invoke-PSDeploy.Tests.ps1
@@ -120,5 +120,55 @@ InModuleScope 'PSDeploy' {
                 $Deployments[0] | Should Be 'mmhmm'
             }
         }
+
+        Context 'Picks up custom PSDeploy.yml scripts in custom path' {
+            $CustomYaml = @'
+CustomScript:
+  Script: CustomScript.ps1
+  Description: Custom script to deploy
+'@
+            $PSDeployYamlPath = Join-Path -Path 'TestDrive:' -ChildPath 'PSDeploy.yml'
+            $CustomYaml | Out-File -FilePath $PSDeployYamlPath -Force
+
+            $CustomScript = @'
+[CmdletBinding()]
+Param (
+    [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [PSObject[]]$Deployment,
+
+    [Parameter(Mandatory=$true)]
+    [System.String]
+    $Path
+)
+
+Set-Content -Path $Path -Value $Deployment.Source
+'@
+            $PSDeployScriptsPath = Join-Path -Path 'TestDrive:' -ChildPath 'PSDeployScripts'
+            New-Item -Path $PSDeployScriptsPath -ItemType Directory > $null
+            $CustomScriptPath = Join-Path -Path $PSDeployScriptsPath -ChildPath 'CustomScript.ps1'
+            $CustomScript | Out-File -FilePath $CustomScriptPath -Force
+
+            $OutputPath = Join-Path -Path 'TestDrive:' -ChildPath 'output.txt'
+            New-Item -Path $OutputPath -ItemType File > $null
+            $CustomDeploy = @"
+Deploy Test {
+    By CustomScript {
+        FromSource '$((Get-Item -Path $PSDeployYamlPath).FullName)'
+        WithOptions @{
+            Path = '$((Get-Item -Path $OutputPath).FullName)'
+        }
+    }
+}
+"@
+            $CustomDeployPath = Join-Path -Path 'TestDrive:' -ChildPath 'custom.psdeploy.ps1'
+            $CustomDeploy | Out-File -FilePath $CustomDeployPath -Force
+
+            Invoke-PSDeploy -Path $CustomDeployPath -PSDeployTypePath $PSDeployYamlPath -Force
+            $Actual = (Get-Content -Path $OutputPath -Raw).Trim()
+
+            It 'Should output both sources specified' {
+                $Actual | Should -Be (Get-Item -Path $PSDeployYamlPath).FullName
+            }
+        }
     }
 }

--- a/Tests/Invoke-PSDeploy.Tests.ps1
+++ b/Tests/Invoke-PSDeploy.Tests.ps1
@@ -167,7 +167,7 @@ Deploy Test {
             $Actual = (Get-Content -Path $OutputPath -Raw).Trim()
 
             It 'Should output both sources specified' {
-                $Actual | Should -Be (Get-Item -Path $PSDeployYamlPath).FullName
+                $Actual | Should Be (Get-Item -Path $PSDeployYamlPath).FullName
             }
         }
     }


### PR DESCRIPTION
The `-PSDeployTypePath` option in `Invoke-PSDeploy` didn't seem to do anything. This PR allows someone to specify a custom `PSDeploy.yml` file that sits outside of the module path and to load scripts that are also outside the module path.