### PR TITLE
Fix for #131, supports PS Core

### DIFF
--- a/PSDeploy/Private/Invoke-Robocopy.ps1
+++ b/PSDeploy/Private/Invoke-Robocopy.ps1
@@ -78,7 +78,7 @@ function Invoke-Robocopy
                     #region Module Builder
                     $Domain = [System.AppDomain]::CurrentDomain
                     $DynAssembly = New-Object -TypeName System.Reflection.AssemblyName($TypeName)
-                    $AssemblyBuilder = $Domain.DefineDynamicAssembly($DynAssembly, [System.Reflection.Emit.AssemblyBuilderAccess]::Run) # Only run in memory
+                    $AssemblyBuilder = [System.Reflection.Emit.AssemblyBuilder]::DefineDynamicAssembly($DynAssembly, [System.Reflection.Emit.AssemblyBuilderAccess]::Run) # Only run in memory
                     $ModuleBuilder = $AssemblyBuilder.DefineDynamicModule($TypeName, $false)
                     #endregion Module Builder
 


### PR DESCRIPTION
It looks like the encoding threw off the file comparison, but I'm not exactly sure why. I've only rewritten line 81 based on suggestions here: https://stackoverflow.com/questions/36937276/is-there-any-replace-of-assemblybuilder-definedynamicassembly-in-net-core