### PR TITLE
Added new Deployment Types

### DIFF
--- a/Build/build.requirements.psd1
+++ b/Build/build.requirements.psd1
@@ -16,4 +16,7 @@
         DependencyType = 'PSGalleryNuget'
         Version = '3.4.6'
     }
+    # Module dependencies for Azure-related deployment types
+    'Az.Automation' = @{ DependencyType = 'PSGalleryNuget' }
+    'Az.Storage' = @{ DependencyType = 'PSGalleryNuget' }
 }

--- a/Build/build.requirements.psd1
+++ b/Build/build.requirements.psd1
@@ -1,22 +1,51 @@
 ﻿@{
     # Some defaults for all dependencies
-    PSDependOptions = @{
-        Target = '$ENV:USERPROFILE\Documents\WindowsPowerShell\Modules'
+    PSDependOptions    = @{
+        Target    = '$ENV:USERPROFILE\Documents\WindowsPowerShell\Modules'
         AddToPath = $True
-        Parameters = @{
+        <# Parameters = @{
             Force = $True
-        }
+        } #>
     }
 
     # Grab some modules without depending on PowerShellGet
-    'psake' = @{ DependencyType = 'PSGalleryNuget' }
-    'PSDeploy' = @{ DependencyType = 'PSGalleryNuget' }
-    'BuildHelpers' = @{ DependencyType = 'PSGalleryNuget' }
-    'Pester' = @{
+    'psake'            = @{
         DependencyType = 'PSGalleryNuget'
-        Version = '3.4.6'
+        Force = $True
+    }
+    'PSDeploy'         = @{
+        DependencyType = 'PSGalleryNuget'
+        Force = $True
+    }
+    'BuildHelpers'     = @{
+        DependencyType = 'PSGalleryNuget'
+        Force = $True
+    }
+    'Pester'           = @{
+        DependencyType = 'PSGalleryNuget'
+        Version        = '3.4.6'
+        Force = $True
     }
     # Module dependencies for Azure-related deployment types
-    'Az.Automation' = @{ DependencyType = 'PSGalleryNuget' }
-    'Az.Storage' = @{ DependencyType = 'PSGalleryNuget' }
+    'Az.Automation'    = @{
+        DependencyType = 'PSGalleryNuget'
+        Force = $True
+        DependsOn      = 'UninstallAzureRM'
+    }
+    'Az.Storage'       = @{
+        DependencyType = 'PSGalleryNuget'
+        Force = $True
+        DependsOn      = 'UninstallAzureRM'
+    }
+
+    'UninstallAzureRm' = @{
+        DependencyType = 'Command'
+        Source         = '
+        if (Get-Module -ListAvailable AzureRM*) {
+            foreach ($module in (Get-Module -ListAvailable AzureRM*).Name |Get-Unique) {
+                Uninstall-module $module
+            }
+        }
+        '
+    }
 }

--- a/Build/build.requirements.psd1
+++ b/Build/build.requirements.psd1
@@ -13,25 +13,36 @@
         DependencyType = 'PSGalleryNuget'
         Force = $True
     }
+
     'PSDeploy'         = @{
         DependencyType = 'PSGalleryNuget'
         Force = $True
     }
+
     'BuildHelpers'     = @{
         DependencyType = 'PSGalleryNuget'
         Force = $True
     }
+
     'Pester'           = @{
         DependencyType = 'PSGalleryNuget'
         Version        = '3.4.6'
         Force = $True
     }
+
     # Module dependencies for Azure-related deployment types
+    'Az.Resources'       = @{
+        DependencyType = 'PSGalleryNuget'
+        Force = $True
+        DependsOn      = 'UninstallAzureRM'
+    }
+
     'Az.Automation'    = @{
         DependencyType = 'PSGalleryNuget'
         Force = $True
         DependsOn      = 'UninstallAzureRM'
     }
+
     'Az.Storage'       = @{
         DependencyType = 'PSGalleryNuget'
         Force = $True
@@ -41,9 +52,14 @@
     'UninstallAzureRm' = @{
         DependencyType = 'Command'
         Source         = '
-        if (Get-Module -ListAvailable AzureRM*) {
-            foreach ($module in (Get-Module -ListAvailable AzureRM*).Name |Get-Unique) {
-                Uninstall-module $module
+        if($env:APPVEYOR) {
+            $azureRMModules = Get-Module -Name AzureRM* -ListAvailable
+            $azureRMModules += Get-Module -Name Azure.* -ListAvailable
+            if ($azureRMModules) {
+                foreach ($module in $azureRMModules | Get-Unique) {
+                    Write-Verbose "Uninstalling module $($module.Name) version $($module.Version)..."
+                    Uninstall-module $module.Name
+                }
             }
         }
         '

--- a/PSDeploy/PSDeploy.yml
+++ b/PSDeploy/PSDeploy.yml
@@ -9,11 +9,19 @@ AppVeyorModule:
 
 Artifactory:
   Script: Artifactory.ps1
-  Description: Deploys files to an Artifactory endpoint. Can deploy individual files or in the case of a folder deployment, can zip the folder contents and send to Artifactory as a single file. 
+  Description: Deploys files to an Artifactory endpoint. Can deploy individual files or in the case of a folder deployment, can zip the folder contents and send to Artifactory as a single file.
 
 ARM:
   Script: ARM.ps1
-  Description: Uses Azure Resource Manager PowerShell cmdlets to deploy a template to Microsoft Azure or Azure Stack 
+  Description: Uses Azure Resource Manager PowerShell cmdlets to deploy a template to Microsoft Azure or Azure Stack
+
+AzureAutomationModule:
+  Script: AzureAutomationModule.ps1
+  Description: Deploys a PowerShell module to an Azure Automation account from a repository like the PowerShell Gallery.
+
+# AzureAutomationRunbook:
+#   Script: AzureAutomationRunbook.ps1
+#   Description: Deploys a PowerShell script as a runbook to an Azure Automation account.
 
 Chocolatey:
   Script: Chocolatey.ps1
@@ -30,7 +38,7 @@ Filesystem:
 FilesystemRemote:
   Script: FilesystemRemote.ps1
   Description: Uses a PowerShell remoting endpoint and Robocopy or Copy-Item for folder and file deployments, respectively.
-  
+
 FileSystemDiff:
   Script: FileSystemDiff.ps1
   Description: Uses the current session to Copy-Item for folder or file deployments, but will check if the target file is different from last deployment.
@@ -86,4 +94,3 @@ NSSM:
 DSCPull:
   Script: DSCPull.ps1
   Description: Deploys a DSC Resource module to a Pull server
-  

--- a/PSDeploy/PSDeploy.yml
+++ b/PSDeploy/PSDeploy.yml
@@ -21,7 +21,11 @@ AzureAutomationModule:
 
 AzureAutomationRunbook:
   Script: AzureAutomationRunbook.ps1
-  Description: Deploys a PowerShell script as a runbook to an Azure Automation account.
+  Description: Deploys a script as a runbook to an Azure Automation account.
+
+AzureAutomationDscConfiguration:
+  Script: AzureAutomationDscConfiguration.ps1
+  Description: Deploys a DSC configuration to an Azure Automation account.
 
 Chocolatey:
   Script: Chocolatey.ps1

--- a/PSDeploy/PSDeploy.yml
+++ b/PSDeploy/PSDeploy.yml
@@ -19,9 +19,9 @@ AzureAutomationModule:
   Script: AzureAutomationModule.ps1
   Description: Deploys a PowerShell module to an Azure Automation account from a repository like the PowerShell Gallery.
 
-# AzureAutomationRunbook:
-#   Script: AzureAutomationRunbook.ps1
-#   Description: Deploys a PowerShell script as a runbook to an Azure Automation account.
+AzureAutomationRunbook:
+  Script: AzureAutomationRunbook.ps1
+  Description: Deploys a PowerShell script as a runbook to an Azure Automation account.
 
 Chocolatey:
   Script: Chocolatey.ps1

--- a/PSDeploy/PSDeployScripts/ARM.ps1
+++ b/PSDeploy/PSDeployScripts/ARM.ps1
@@ -10,7 +10,7 @@
     .PARAMETER Deployment
         Deployment to run
 #>
-#Requires -modules AzureRM.Resources
+#Requires -modules Az.Resources
 [cmdletbinding()]
 param (
     [ValidateScript({ $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
@@ -26,29 +26,29 @@ foreach($Map in $Deployment)
         # In this case, Targets refers to a Resource Group
         $Targets = $Map.Targets
         foreach($Target in $Targets)
-        {   
+        {
             # These parameters will always be present when following the scenario of deploying from a template file.
             $deploymentParameters = @{
                 'ResourceGroupName' = $Target
                 'TemplateFile' = $Map.Source
             }
-            
+
             # There are additional parameters to consider.
             # Parameter files should probably always exist but there might be cases where a template is very simple and someone wants the deployment to prompt for input.
             foreach ($option in $Map.DeploymentOptions.Keys) {
                 $deploymentParameters.Add($option,$Map.DeploymentOptions.$option)
             }
-                                    
+
             # Not sure this should handle RG creation.  Staging for now.
             # Resource groups are seperate from deployments.  Verify the target exists.
             <#
-            $ResourceGroup = Get-AzureRmResourceGroup -Name $Target -ErrorAction 'SilentlyContinue'
-            if (!$ResourceGroup) {$ResourceGroup = New-AzureRmResourceGroup -Name $Target -Location $Map.DeploymentOptions.ResourceGroupLocation}
+            $ResourceGroup = Get-AzResourceGroup -Name $Target -ErrorAction 'SilentlyContinue'
+            if (!$ResourceGroup) {$ResourceGroup = New-AzResourceGroup -Name $Target -Location $Map.DeploymentOptions.ResourceGroupLocation}
             #>
-            
+
             # The deployment actually happens here
             Write-Verbose "Deploying template '$($Map.Source)' to '$Target'"
-            New-AzureRmResourceGroupDeployment @deploymentParameters
+            New-AzResourceGroupDeployment @deploymentParameters
         }
     }
 }

--- a/PSDeploy/PSDeployScripts/AzureAutomationDscConfiguration.ps1
+++ b/PSDeploy/PSDeployScripts/AzureAutomationDscConfiguration.ps1
@@ -4,8 +4,9 @@
 
     .DESCRIPTION
         Deploys a DSC configuration from a local source file to an Azure Automation account.
+        Supports the same parameters as Import-AzAutomationDscConfiguration cmdlet
 
-
+    .EXAMPLE
         Sample snippet for 'hybridWorkerConfiguration.ps1' configuration:
 
         By AzureAutomationDscConfiguration {
@@ -37,10 +38,10 @@
     .PARAMETER ConfigurationTags
         Tags to assign to the imported configuration
 
-    .PARAMETER Published,
+    .PARAMETER Published
         Configuration should be published after import
 
-    .PARAMETER LogVerbose,
+    .PARAMETER LogVerbose
         Configuration should log detailed information for compilation jobs
 
     .PARAMETER Force
@@ -106,6 +107,24 @@ param(
 )
 
 function New-DscNodeConfiguration {
+    <#
+    .SYNOPSIS
+        Compiles imported configuration.
+    .PARAMETER ConfigurationName
+        Name of the imported DSC configuration to use
+    .PARAMETER CompilationParameters
+        Compilation job parameters
+    .PARAMETER ConfigurationData
+        A hashtable of configuration data to compile the configuration
+    .PARAMETER IncrementNodeConfigurationBuild
+        Switch to increment compiled configuration version
+    .PARAMETER ResourceGroupName
+        Name of the resource group that contains the Automation account
+    .PARAMETER AutomationAccountName
+        Name of the target Automation account
+    .OUTPUTS
+        Microsoft.Azure.Commands.Automation.Model.CompilationJob
+    #>
     [CmdletBinding()]
     [OutputType([Microsoft.Azure.Commands.Automation.Model.CompilationJob])]
     param (

--- a/PSDeploy/PSDeployScripts/AzureAutomationDscConfiguration.ps1
+++ b/PSDeploy/PSDeployScripts/AzureAutomationDscConfiguration.ps1
@@ -1,0 +1,266 @@
+<#
+    .SYNOPSIS
+        Deploys a DSC configuration to an Azure Automation account.
+
+    .DESCRIPTION
+        Deploys a DSC configuration from a local source file to an Azure Automation account.
+
+
+        Sample snippet for 'hybridWorkerConfiguration.ps1' configuration:
+
+        By AzureAutomationDscConfiguration {
+            FromSource "C:\Source\hybridWorkerConfiguration.ps1"
+            To "MyAutomationAccountName"
+            WithOptions @{
+                ConfigurationDescription        = "My DSC configuration" # Optional
+                ConfigurationTags               = @{key0="value0";key1="value1"} # Optional
+                Published                       = $false # Optional
+                LogVerbose                      = $false # Optional
+                Published                       = $false # Optional
+                Force                           = $false # Optional
+                ResourceGroupName               = "MyAutomationAccount_ResourceGroupName"
+                Compile                         = $false # Optional
+                CompilationParameters           = @{parameter0="value0";parameter1="value1"} # Optional
+                ConfigurationData               = @{AllNodes = @(@{NodeName = "localhost";Modules = @("PSDscResources")})}; # Optional
+                IncrementNodeConfigurationBuild = $false # Optional
+        }
+
+    .PARAMETER Deployment
+        Deployment to run
+
+    .PARAMETER ResourceGroupName
+        The resource group of target Azure Automation account
+
+    .PARAMETER ConfigurationDescription
+        Configuration description
+
+    .PARAMETER ConfigurationTags
+        Tags to assign to the imported configuration
+
+    .PARAMETER Published,
+        Configuration should be published after import
+
+    .PARAMETER LogVerbose,
+        Configuration should log detailed information for compilation jobs
+
+    .PARAMETER Force
+        Overwrite an existing configuration with the same name if there is any
+
+    .PARAMETER Compile
+        Configuration should be compiled after import
+
+    .PARAMETER CompilationParameters
+        A dictionary of parameters to compile the DSC configuration
+
+    .PARAMETER ConfigurationData
+        A dictionary of configuration data to compile DSC configuration
+
+    .PARAMETER IncrementNodeConfigurationBuild
+        Create a new Node Configuration build version
+
+    .OUTPUTS
+        Microsoft.Azure.Commands.Automation.Model.DscConfiguration
+#>
+
+#Requires -modules Az.Automation
+[CmdletBinding()]
+[OutputType([Microsoft.Azure.Commands.Automation.Model.DscConfiguration])]
+param(
+    [ValidateScript( { $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [psobject[]]$Deployment,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ResourceGroupName,
+
+    #region Import parameters
+    [Parameter(Mandatory = $false)]
+    [string]$ConfigurationDescription,
+
+    [Parameter(Mandatory = $false)]
+    [hashtable]$ConfigurationTags,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Published,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$LogVerbose,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Force,
+    #endregion
+
+    #region Compilation parameters
+    [Parameter(Mandatory = $false)]
+    [switch]$Compile,
+
+    [Parameter(Mandatory = $false)]
+    [hashtable]$CompilationParameters,
+
+    [Parameter(Mandatory = $false)]
+    [hashtable]$ConfigurationData,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$IncrementNodeConfigurationBuild
+    #endregion
+)
+
+function New-DscNodeConfiguration {
+    [CmdletBinding()]
+    [OutputType([Microsoft.Azure.Commands.Automation.Model.CompilationJob])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ConfigurationName,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$CompilationParameters,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$ConfigurationData,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IncrementNodeConfigurationBuild,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ResourceGroupName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$AutomationAccountName
+    )
+
+    begin {
+        Write-Verbose "Initiating '$ConfigurationName' configuration compilation job..."
+    }
+
+    process {
+        #region Start-AzAutomationDscCompilationJob parameters
+        $params = @{
+            ConfigurationName     = $ConfigurationName
+            AutomationAccountName = $AutomationAccountName
+            ResourceGroupName     = $ResourceGroupName
+            Verbose               = $VerbosePreference
+        }
+
+        if ($CompilationParameters) {
+            $params['CompilationParameters'] = $CompilationParameters
+        }
+
+        if ($ConfigurationData) {
+            $params['ConfigurationData'] = $ConfigurationData
+        }
+
+        if ($IncrementNodeConfigurationBuild) {
+            $params['IncrementNodeConfigurationBuild'] = $IncrementNodeConfigurationBuild
+        }
+        #endregion
+
+        $compilationJob = Start-AzAutomationDscCompilationJob @params
+
+        while ($null -eq $compilationJob.EndTime -and $null -eq $compilationJob.Exception) {
+            Write-Verbose "Compilation job status is: $($compilationJob.Status)"
+            $compilationJob = $compilationJob | Get-AzAutomationDscCompilationJob
+            Start-Sleep -Seconds 5
+        }
+
+        if ($compilationJob.Status -eq 'Completed') {
+            Write-Verbose "Compilation job status is: $($compilationJob.Status)"
+
+            #region Get-AzAutomationDscNodeConfiguration parameters
+            $params = @{
+                AutomationAccountName = $compilationJob.AutomationAccountName
+                ResourceGroupName     = $compilationJob.ResourceGroupName
+                Verbose               = $VerbosePreference
+            }
+            #endregion
+
+            $compiledConfiguration = Get-AzAutomationDscNodeConfiguration @params | Where-Object -Property ConfigurationName -EQ $ConfigurationName
+        }
+        else {
+            throw "The compilation job has failed. Check the Azure portal for the exception details."
+        }
+    }
+
+    end {
+        # Return the compilation job
+        Write-Output $compiledConfiguration
+    }
+}
+
+foreach ($deploy in $Deployment) {
+
+    foreach ($target in $deploy.Targets) {
+        Write-Verbose "Starting deployment '$($deploy.DeploymentName)' to Azure Automation account '$target' in '$ResourceGroupName' resource group."
+
+        #region Import-AzAutomationDscConfiguration parameters
+        $params = @{
+            SourcePath            = $deploy.Source
+            AutomationAccountName = $target
+            ResourceGroupName     = $ResourceGroupName
+            Verbose               = $VerbosePreference
+        }
+
+        if ($ConfigurationDescription) {
+            $params['ConfigurationDescription'] = $ConfigurationDescription
+        }
+
+        if ($ConfigurationTags) {
+            $params['ConfigurationTags'] = $ConfigurationTags
+        }
+
+        if ($ConfigurationTags) {
+            $params['ConfigurationTags'] = $ConfigurationTags
+        }
+
+        if ($Published) {
+            $params['Published'] = $Published
+        }
+
+        if ($LogProgress) {
+            $params['LogProgress'] = $LogProgress
+        }
+
+        if ($Force) {
+            $params['Force'] = $Force
+        }
+        #endregion
+
+        $importedDscConfiguration = Import-AzAutomationDscConfiguration @params
+
+        Write-Verbose "The configuration '$($importedDscConfiguration.Name)' has been imported to '$target' Azure Automation account."
+
+        if ($Compile -and $importedDscConfiguration) {
+
+            # New-DscCompiledConfiguration parameters
+            $params = @{
+                ConfigurationName     = $importedDscConfiguration.Name
+                AutomationAccountName = $importedDscConfiguration.AutomationAccountName
+                ResourceGroupName     = $importedDscConfiguration.ResourceGroupName
+                Verbose               = $VerbosePreference
+            }
+
+            if ($CompilationParameters) {
+                $params['CompilationParameters'] = $CompilationParameters
+            }
+
+            if ($ConfigurationData) {
+                $params['ConfigurationData'] = $ConfigurationData
+            }
+
+            if ($IncrementNodeConfigurationBuild) {
+                $params['IncrementNodeConfigurationBuild'] = $IncrementNodeConfigurationBuild
+            }
+
+            $compiledConfiguration = New-DscNodeConfiguration @params
+        }
+
+        if ($importedDscConfiguration) {
+            # Return the imported configuration
+            Write-Output $importedDscConfiguration
+        }
+
+        Write-Verbose "The deployment '$($deploy.DeploymentName)' completed."
+    }
+}

--- a/PSDeploy/PSDeployScripts/AzureAutomationModule.ps1
+++ b/PSDeploy/PSDeployScripts/AzureAutomationModule.ps1
@@ -1,0 +1,559 @@
+<#
+    .SYNOPSIS
+        Deploys a module to an Azure Automation account.
+
+    .DESCRIPTION
+        Deploys a PowerShell module to an Azure Automation account from a repository like the PowerShell Gallery.
+        Supports credentials to access private repositories.
+        Inspired by https://blog.tyang.org/2017/02/17/managing-azure-automation-module-assets-using-myget/
+
+        Sample snippet for PSDeploy configuration:
+
+        By AzureAutomationModule {
+            FromSource "https://www.powershellgallery.com/api/v2"
+            To "MyAutomationAccountName"
+            WithOptions @{
+                SourceIsAbsolute  = $true # Should be true if deploying from a gallery, and false if deploying from a local path
+                ModuleName        = "PSDepend"
+                ModuleVersion     = '0.3.0' # Optional. If not specified, the latest module version will be used.
+                ResourceGroupName = "MyAutomationAccount_ResourceGroupName"
+                Force             = $true # Optional. Use if you want to overwrite an already imported module with the same or lower module version.
+        }
+    }
+
+    .PARAMETER Deployment
+        Deployment to run
+
+    .PARAMETER ModuleName
+        Module to deploy
+
+    .PARAMETER ModuleVersion
+        Specific module version to use for deployment
+
+    .PARAMETER PsGalleryApiUrl
+        URL of PowerShell repository API
+
+    .PARAMETER Credential
+        Credential to use for accessing the PowerShell repository
+
+    .PARAMETER Force
+        Deploy the module even if the same module version is already imported into Azure Automation account
+
+    .PARAMETER AutomationAccountName
+        Azure Automation account to import the module
+
+    .PARAMETER AutomationAccountResourceGroup
+        The resource group of target Azure Automation account
+#>
+
+#Requires -modules Az.Automation
+[CmdletBinding()]
+param(
+    [ValidateScript( { $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [psobject[]]$Deployment,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ModuleName,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ModuleVersion,
+
+    [Parameter(Mandatory = $false)]
+    [pscredential]$Credential,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Force,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ResourceGroupName
+)
+
+function Get-SourceModuleRepository {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $SourceLocation,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ModuleName,
+
+        [Parameter(Mandatory = $false)]
+        [pscredential]$Credential
+    )
+
+    begin {
+        Write-Verbose "Starting the configuration of target module repository to work with..."
+    }
+
+    process {
+        Write-Verbose "Searching for a registered PowerShell repository with SourceLocation '$SourceLocation'..."
+
+        $existingPSRepository = Get-PSRepository | Where-Object -Property SourceLocation -eq $SourceLocation
+
+        if ($existingPSRepository) {
+            Write-Verbose "An already registered repository '$($existingPSRepository.Name)' with the same SourceLocation has been found."
+
+            # Setting target repository name
+            $targetRepositoryName = $existingPSRepository.Name
+        }
+        else {
+            Write-Verbose "No registered repository has been found. Registering a new PowerShell repository..."
+
+            # Register-PSRepository parameters
+            $params = @{
+                Name           = $ModuleName + '-repository'
+                SourceLocation = $SourceLocation
+                Verbose        = $VerbosePreference
+            }
+
+            if ($Credential) {
+                $params['Credential'] = $Credential
+            }
+
+            # Register a new repository
+            Register-PSRepository @params
+
+            # Setting target repository name
+            $targetRepositoryName = $ModuleName + '-repository'
+        }
+    }
+
+    end {
+        Write-Verbose "The following PowerShell repository will be used as the target repository '$targetRepositoryName'."
+        # Return the target repository
+        Get-PSRepository -Name $targetRepositoryName | Write-Output
+    }
+}
+
+function Get-SourceModule {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ModuleName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Repository,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $RequiredVersion,
+
+        [Parameter(Mandatory = $false)]
+        [pscredential]$Credential
+    )
+
+    begin {
+        if ($ModuleVersion) {
+            Write-Verbose "Searching for version '$RequiredVersion' of module '$ModuleName' in the repository '$Repository'..."
+        }
+        else {
+            Write-Verbose "Searching for the latest version of module '$ModuleName' in the repository '$Repository'..."
+        }
+    }
+
+    process {
+        # Find-Module parameters
+        $params = @{
+            Name       = $ModuleName
+            Repository = $Repository
+            Verbose    = $VerbosePreference
+        }
+
+        if ($ModuleVersion) {
+            $params['RequiredVersion'] = $RequiredVersion
+        }
+
+        if ($Credential) {
+            $params['Credential'] = $Credential
+        }
+
+        # Look for the module
+        $sourceModule = Find-Module @params
+
+    }
+
+    end {
+        if ($sourceModule) {
+            Write-Verbose "The version '$($sourceModule.Version)' of module '$($sourceModule.Name)' is found in the repository '$Repository'."
+        }
+        else {
+            Write-Verbose "No target version of module '$ModuleName' is found in the repository '$Repository'."
+        }
+
+        # Return the target module
+        Write-Output $sourceModule
+    }
+}
+
+function Get-ModuleImportStatus {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        $ModuleImportJob
+    )
+
+    begin {
+        $importCompleted = $false
+    }
+
+    process {
+        do {
+            Write-Verbose 'Checking module import status...'
+            $importedModule = Get-AzAutomationModule -Name $ModuleImportJob.Name -ResourceGroupName $ModuleImportJob.ResourceGroupName -AutomationAccountName $ModuleImportJob.AutomationAccountName
+            if (($importedModule.ProvisioningState -eq 'Succeeded') -or ($importedModule.ProvisioningState -eq 'Failed')) {
+                $importCompleted = $true
+            }
+            Start-Sleep -Seconds 5
+        }
+        until ($importCompleted -eq $true)
+    }
+
+    end {
+        Write-Verbose "Module import status is: $($importedModule.ProvisioningState)"
+        # Return the import job status
+        # Write-Output $importedModule
+    }
+}
+
+function Get-ImportedModule {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ModuleName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $AutomationAccountName,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $ResourceGroupName
+    )
+
+    begin {
+        Write-Verbose "Searching for an existing module '$ModuleName' in the Automation account '$AutomationAccountName'..."
+    }
+
+    process {
+        # Get-AzAutomationModule parameters
+        $params = @{
+            Name                  = $ModuleName
+            AutomationAccountName = $AutomationAccountName
+            ResourceGroupName     = $ResourceGroupName
+            Verbose               = $VerbosePreference
+        }
+
+        $importedModule = Get-AzAutomationModule @params
+    }
+
+    end {
+        if ($importedModule) {
+            Write-Verbose "An existing module '$($importedModule.Name)' version '$($importedModule.Version)' was found in the Automation account '$($importedModule.AutomationAccountName)'."
+
+            # Return the imported module
+            Write-Output $importedModule
+        }
+        else {
+            Write-Verbose "No existing module '$ModuleName' was found in the Automation account '$AutomationAccountName'."
+        }
+    }
+}
+
+function Import-SourceModule {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        $Module,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Microsoft.Azure.Commands.Automation.Model.AutomationAccount]
+        $AutomationAccount
+    )
+
+    begin {
+
+    }
+
+    process {
+        #region Searching for the source module in the Azure Automation account
+        # Get-SourceModule parameters
+        $params = @{
+            ModuleName            = $Module.Name
+            AutomationAccountName = $AutomationAccount.AutomationAccountName
+            ResourceGroupName     = $AutomationAccount.ResourceGroupName
+            Verbose               = $VerbosePreference
+        }
+
+        $targetModule = Get-ImportedModule @params
+        #endregion
+
+        # New-AzAutomationModule parameters
+        $params = @{
+            Name                  = $Module.Name
+            AutomationAccountName = $AutomationAccount.AutomationAccountName
+            ResourceGroupName     = $AutomationAccount.ResourceGroupName
+            ContentLink           = $Module.RepositorySourceLocation + "/package/$($Module.Name)/$($Module.Version)/"
+            Verbose               = $VerbosePreference
+        }
+
+        if ($targetModule) {
+            if ($sourceModule.Version -gt ([version]::Parse($targetModule.Version))) {
+                Write-Verbose "The source module version is '$($sourceModule.Version)', which is greater than the existing version in the Automation Account. Updating now..."
+                $moduleImportJob = New-AzAutomationModule @params
+            }
+            elseif (($sourceModule.Version -le ([version]::Parse($targetModule.Version))) -and $Force) {
+                Write-Warning "Forcing the target module import!"
+
+                # Remove-AzAutomationModule parameters
+                $removeParams = @{
+                    Name                  = $targetModule.Name
+                    AutomationAccountName = $target
+                    ResourceGroupName     = $deploy.DeploymentOptions.ResourceGroupName
+                    Force                 = $deploy.DeploymentOptions.Force
+                    Verbose               = $VerbosePreference
+                }
+
+                Write-Warning "Removing the version '$($targetModule.Version)' of module '$($targetModule.Name)' from the the Automation Account '$target'..."
+                Remove-AzAutomationModule @removeParams
+
+                Write-Verbose "Importing the version '$($sourceModule.Version)' of module '$($sourceModule.Name)' into the Automation Account '$target'..."
+                $moduleImportJob = New-AzAutomationModule @params
+            }
+            elseif ($sourceModule.Version -eq ([version]::Parse($targetModule.Version))) {
+                Write-Verbose "The source module version is '$($sourceModule.Version)', which is the same as the existing version in the Automation Account. Update is not required."
+            }
+            else {
+                Write-Verbose "The source module version is '$($sourceModule.Version)', which is lower than the existing version '$($targetModule.Version)' in the Automation Account. Update is not required."
+            }
+        }
+        else {
+            Write-Verbose "Importing the version '$($sourceModule.Version)' of module '$($sourceModule.Name)' into the Automation Account '$target'..."
+            $moduleImportJob = New-AzAutomationModule @params
+        }
+    }
+
+    end {
+        Write-Output $moduleImportJob
+    }
+}
+
+foreach ($deploy in $Deployment) {
+
+    foreach ($target in $deploy.Targets) {
+        Write-Verbose "Starting deployment '$($deploy.DeploymentName)' to Azure Automation account '$target' in '$ResourceGroupName' resource group."
+
+        #region Setting up the module repository
+
+        # Get-SourceModuleRepository parameters
+        $params = @{
+            ModuleName     = $deploy.DeploymentOptions.ModuleName
+            SourceLocation = $deploy.Source
+            Verbose        = $VerbosePreference
+        }
+
+        if ($Credential) {
+            $params['Credential'] = $deploy.DeploymentOptions.Credential
+        }
+
+        $sourceModuleRepository = Get-SourceModuleRepository @params
+
+        #region Searching for the target module in the repository
+        if ($sourceModuleRepository) {
+
+            # Get-SourceModule parameters
+            $params = @{
+                ModuleName = $deploy.DeploymentOptions.ModuleName
+                Repository = $sourceModuleRepository.Name
+                Verbose    = $VerbosePreference
+            }
+
+            if ($ModuleVersion) {
+                $params['RequiredVersion'] = $ModuleVersion
+            }
+
+            if ($Credential) {
+                $params['Credential'] = $Credential
+            }
+
+            $sourceModule = Get-SourceModule @params
+
+            #region Importing the target module into an Azure Automation account
+            if ($sourceModule) {
+
+                $targetAzureAutomationAccount = Get-AzAutomationAccount -Name $target -ResourceGroupName $deploy.DeploymentOptions.ResourceGroupName
+
+                if ($targetAzureAutomationAccount) {
+                    # Import-SourceModule parameters
+                    $params = @{
+                        Module            = $sourceModule
+                        AutomationAccount = $targetAzureAutomationAccount
+                        Verbose           = $VerbosePreference
+                    }
+
+                    $moduleImportJob = Import-SourceModule @params
+
+                    if ($moduleImportJob) {
+                        $moduleImportJob | Get-ModuleImportStatus
+                    }
+                }
+                else {
+                    throw "The target Azure Automation account '$target' was not found in '$($deploy.DeploymentOptions.ResourceGroupName)' resource group."
+                }
+            }
+            else {
+                if ($ModuleVersion) {
+                    throw "The version '$ModuleVersion' of source module '$($deploy.DeploymentOptions.ModuleName)' was not found in the repository '$($sourceModuleRepository.Name)'."
+                }
+                else {
+                    throw "The source module '$($deploy.DeploymentOptions.ModuleName)' was not found in the repository '$($sourceModuleRepository.Name)'."
+                }
+            }
+            #endregion
+
+        }
+        else {
+            throw "Cannot register source module repository."
+        }
+        #endregion
+    }
+}
+
+# TODO - Implement deployment from a private repository
+# Need to create a storage account in the target Azure Automation account resource group
+# Create a container, upload zipped module to the storage account and get its download link
+
+function New-ContentLinkUri {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Microsoft.Azure.Commands.Automation.Model.AutomationAccount]
+        $AutomationAccount,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path
+    )
+
+    begin {
+    }
+
+    process {
+        # New-AzStorageAccount parameters
+        $params = @{
+            Name              = $((Split-Path $Path -LeafBase) + 'stor')
+            Location          = $AutomationAccount.Location
+            ResourceGroupName = $AutomationAccount.ResourceGroupName
+            SkuName           = "Standard_LRS"
+            Verbose           = $VerbosePreference
+        }
+
+        # Create a storage account
+        $storageAccount = New-AzStorageAccount @params
+
+        $context = $storageAccount.Context
+
+        # Create a container
+        New-AzStorageContainer -Name $containerName -Context $context -Permission Container
+
+        # Set-AzStorageBlobContent parameters
+        $params = @{
+            Container = $containerName
+            File      = $Path
+            Blob      = $(Split-Path $Path -Leaf)
+            Context   = $context
+            Verbose   = $VerbosePreference
+        }
+
+        # Upload the file
+        Set-AzStorageBlobContent @params
+
+        # Get secure context
+        $key = (Get-AzStorageAccountKey -ResourceGroupName $storageAccount.ResourceGroupName -Name $storageAccount.StorageAccountName).Value[0]
+        $context = New-AzStorageContext -StorageAccountName $storageAccount.StorageAccountName -StorageAccountKey $key
+
+        # New-AzStorageBlobSASToken parameters
+        $params = @{
+            Context    = $context
+            Container  = $containerName
+            Blob       = $(Split-Path $Path -Leaf)
+            Permission = 'r'
+            ExpiryTime = (Get-Date).AddHours(2.0)
+            FullUri    = $true
+            Verbose    = $VerbosePreference
+        }
+
+        # Generate a SAS token
+        $contentLinkUri = New-AzStorageBlobSASToken @params
+    }
+
+    end {
+        Write-Output $contentLinkUri
+    }
+}
+
+function New-ModuleZipFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'PSRepository')]
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        $Module,
+        [Parameter(Mandatory = $false, ParameterSetName = 'PSRepository')]
+        [pscredential]$Credential,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Local source')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path
+    )
+
+    begin {
+
+    }
+
+    process {
+        # Creating a zip file from the module in the source repository
+        if ($Module) {
+
+            # Save-Module parameters
+            $params = @{
+                InputObject = $Module
+                Path        = $PSScriptRoot
+                Force       = $true
+                Verbose     = $VerbosePreference
+            }
+
+            if ($Credential) {
+                $params['Credential'] = $Credential
+            }
+
+            $sourceModulePath = Save-Module @params
+        }
+        # Creating a zip file from the local source path
+        elseif ($Path) {
+            $sourceModulePath = $Path
+        }
+
+        $zipFile = Compress-Archive -Path $sourceModulePath -DestinationPath $("{0}.zip" -f (Get-Item -Path $sourceModulePath).FullName) -Force
+    }
+
+    end {
+        Write-Output $zipFile
+    }
+}

--- a/PSDeploy/PSDeployScripts/AzureAutomationModule.ps1
+++ b/PSDeploy/PSDeployScripts/AzureAutomationModule.ps1
@@ -87,7 +87,7 @@
         The Storage account to use for module upload
 #>
 
-#Requires -modules Az.Automation
+#Requires -modules Az.Automation, Az.Storage
 [CmdletBinding()]
 param(
     [ValidateScript( { $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]

--- a/PSDeploy/PSDeployScripts/AzureAutomationRunbook.ps1
+++ b/PSDeploy/PSDeployScripts/AzureAutomationRunbook.ps1
@@ -7,7 +7,7 @@
         Supports the same deployment runbook types as Import-AzAutomationRunbook cmdlet
         (https://docs.microsoft.com/en-us/powershell/module/az.automation/import-azautomationrunbook).
 
-        Sample snippet for PSDeploy configuration:
+        Sample snippet for 'MyRunbook01.ps1' configuration:
 
         By AzureAutomationRunbook {
             FromSource "C:\Source\MyRunbook01.ps1"
@@ -54,6 +54,9 @@
 
     .PARAMETER ResourceGroupName
         The resource group of target Azure Automation account
+
+    .OUTPUTS
+        Microsoft.Azure.Commands.Automation.Model.Runbook
 #>
 
 #Requires -modules Az.Automation

--- a/PSDeploy/PSDeployScripts/AzureAutomationRunbook.ps1
+++ b/PSDeploy/PSDeployScripts/AzureAutomationRunbook.ps1
@@ -61,6 +61,7 @@
 
 #Requires -modules Az.Automation
 [CmdletBinding()]
+[OutputType([Microsoft.Azure.Commands.Automation.Model.Runbook])]
 param(
     [ValidateScript( { $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
     [psobject[]]$Deployment,

--- a/PSDeploy/PSDeployScripts/AzureAutomationRunbook.ps1
+++ b/PSDeploy/PSDeployScripts/AzureAutomationRunbook.ps1
@@ -7,6 +7,7 @@
         Supports the same deployment runbook types as Import-AzAutomationRunbook cmdlet
         (https://docs.microsoft.com/en-us/powershell/module/az.automation/import-azautomationrunbook).
 
+    .EXAMPLE
         Sample snippet for 'MyRunbook01.ps1' configuration:
 
         By AzureAutomationRunbook {
@@ -22,8 +23,8 @@
                 LogVerbose         = $false # Optional
                 Force              = $false # Optional
                 ResourceGroupName  = "MyAutomationAccount_ResourceGroupName"
+            }
         }
-    }
 
     .PARAMETER Deployment
         Deployment to run
@@ -40,13 +41,13 @@
     .PARAMETER RunbookType
         Azure Automation runbook type
 
-    .PARAMETER Published,
+    .PARAMETER Published
         Runbook should be published after import
 
-    .PARAMETER LogProgress,
+    .PARAMETER LogProgress
         Runbook should log progress information
 
-    .PARAMETER LogVerbose,
+    .PARAMETER LogVerbose
         Runbook should log detailed information
 
     .PARAMETER Force

--- a/PSDeploy/PSDeployScripts/AzureAutomationRunbook.ps1
+++ b/PSDeploy/PSDeployScripts/AzureAutomationRunbook.ps1
@@ -1,0 +1,139 @@
+<#
+    .SYNOPSIS
+        Deploys a runbook to an Azure Automation account.
+
+    .DESCRIPTION
+        Deploys a runbook from a local source file to an Azure Automation account.
+        Supports the same deployment runbook types as Import-AzAutomationRunbook cmdlet
+        (https://docs.microsoft.com/en-us/powershell/module/az.automation/import-azautomationrunbook).
+
+        Sample snippet for PSDeploy configuration:
+
+        By AzureAutomationRunbook {
+            FromSource "C:\Source\MyRunbook01.ps1"
+            To "MyAutomationAccountName"
+            WithOptions @{
+                RunbookName        = "MyRunbook01"
+                RunbookDescription = "My Runbook version 01" # Optional
+                RunbookTags        = @{key0="value0";key1="value1"} # Optional
+                RunbookType        = "PowerShell" # Optional. If not specified, will try to import the source as a PowerShell runbook.
+                Published          = $false # Optional
+                LogProgress        = $false # Optional
+                LogVerbose         = $false # Optional
+                Force              = $false # Optional
+                ResourceGroupName  = "MyAutomationAccount_ResourceGroupName"
+        }
+    }
+
+    .PARAMETER Deployment
+        Deployment to run
+
+    .PARAMETER RunbookName
+        Runbook name to use
+
+    .PARAMETER RunbookDescription
+        Runbook description
+
+    .PARAMETER RunbookTags
+        Tags to assign to the imported runbook
+
+    .PARAMETER RunbookType
+        Azure Automation runbook type
+
+    .PARAMETER Published,
+        Runbook should be published after import
+
+    .PARAMETER LogProgress,
+        Runbook should log progress information
+
+    .PARAMETER LogVerbose,
+        Runbook should log detailed information
+
+    .PARAMETER Force
+        Overwrite an existing runbook with the same name if there is any
+
+    .PARAMETER ResourceGroupName
+        The resource group of target Azure Automation account
+#>
+
+#Requires -modules Az.Automation
+[CmdletBinding()]
+param(
+    [ValidateScript( { $_.PSObject.TypeNames[0] -eq 'PSDeploy.Deployment' })]
+    [psobject[]]$Deployment,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$RunbookName,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RunbookDescription,
+
+    [Parameter(Mandatory = $false)]
+    [hashtable]$RunbookTags,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('PowerShell', 'GraphicalPowerShell', 'PowerShellWorkflow', 'GraphicalPowerShellWorkflow', 'Graph', 'Python2')]
+    [string]$RunbookType = 'PowerShell',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Published,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$LogProgress,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$LogVerbose,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Force,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ResourceGroupName
+)
+
+foreach ($deploy in $Deployment) {
+
+    foreach ($target in $deploy.Targets) {
+        Write-Verbose "Starting deployment '$($deploy.DeploymentName)' to Azure Automation account '$target' in '$ResourceGroupName' resource group."
+
+        # Import-AzAutomationRunbook parameters
+        $params = @{
+            Path                  = $deploy.Source
+            Name                  = $RunbookName
+            Type                  = $RunbookType
+            AutomationAccountName = $target
+            ResourceGroupName     = $ResourceGroupName
+            Verbose               = $VerbosePreference
+        }
+
+        if ($RunbookDescription) {
+            $params['RunbookDescription'] = $RunbookDescription
+        }
+
+        if ($RunbookTags) {
+            $params['RunbookTags'] = $RunbookTags
+        }
+
+        if ($Published) {
+            $params['Published'] = $Published
+        }
+
+        if ($LogProgress) {
+            $params['LogProgress'] = $LogProgress
+        }
+
+        if ($LogVerbose) {
+            $params['LogVerbose'] = $LogVerbose
+        }
+
+        if ($Force) {
+            $params['Force'] = $Force
+        }
+
+        Import-AzAutomationRunbook @params
+
+        Write-Verbose "The deployment '$($deploy.DeploymentName)' completed."
+    }
+}

--- a/Tests/Types/AzureAutomationDscConfiguration.Tests.ps1
+++ b/Tests/Types/AzureAutomationDscConfiguration.Tests.ps1
@@ -20,22 +20,22 @@ InModuleScope 'PSDeploy' {
 
         Context "Code Style" {
             It "should define CmdletBinding" {
-                $sutPath | Should -FileContentMatch 'CmdletBinding'
+                $sutPath | Should Contain 'CmdletBinding'
             }
 
             It "should define parameters" {
-                $sutPath | Should -FileContentMatch 'Param'
+                $sutPath | Should Contain 'Param'
             }
 
             It "should contain Write-Verbose blocks" {
-                $sutPath | Should -FileContentMatch 'Write-Verbose'
+                $sutPath | Should Contain 'Write-Verbose'
             }
 
             It "should be a valid PowerShell code" {
                 $psFile = Get-Content -Path $sutPath -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
-                $errors.Count | Should -Be 0
+                $errors.Count | Should Be 0
             }
         }
 
@@ -49,15 +49,15 @@ InModuleScope 'PSDeploy' {
             $scriptHelp = $parsedScript.GetHelpContent()
 
             It "should have a SYNOPSIS" {
-                $scriptHelp.Synopsis | Should -Not -BeNullOrEmpty
+                $scriptHelp.Synopsis | Should Not BeNullOrEmpty
             }
 
             It "should have a DESCRIPTION" {
-                $scriptHelp.Description.Length | Should -Not -BeNullOrEmpty
+                $scriptHelp.Description.Length | Should Not BeNullOrEmpty
             }
 
             It "should have at least one EXAMPLE" {
-                $scriptHelp.Examples.Count | Should -BeGreaterThan 0
+                $scriptHelp.Examples.Count | Should BeGreaterThan 0
             }
 
             # Getting the list of function parameters
@@ -65,7 +65,7 @@ InModuleScope 'PSDeploy' {
 
             foreach ($parameter in $parameters) {
                 It "should have descriptive help for '$parameter' parameter" {
-                    $scriptHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty
+                    $scriptHelp.Parameters.($parameter.ToUpper()) | Should Not BeNullOrEmpty
                 }
             }
         }
@@ -179,7 +179,7 @@ InModuleScope 'PSDeploy' {
 
             It "should output into the pipeline" {
                 $result = { Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationDscConfiguration.psdeploy.ps1" -Force }
-                $result | Should -Not -BeNullOrEmpty
+                $result | Should Not BeNullOrEmpty
             }
         }
     }

--- a/Tests/Types/AzureAutomationDscConfiguration.Tests.ps1
+++ b/Tests/Types/AzureAutomationDscConfiguration.Tests.ps1
@@ -66,7 +66,6 @@ InModuleScope 'PSDeploy' {
             foreach ($parameter in $parameters) {
                 It "should have descriptive help for '$parameter' parameter" {
                     $scriptHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty
-                    # $scriptHelp.Parameters.($parameter.ToUpper()).Length | Should -BeGreaterThan 15
                 }
             }
         }

--- a/Tests/Types/AzureAutomationDscConfiguration.Tests.ps1
+++ b/Tests/Types/AzureAutomationDscConfiguration.Tests.ps1
@@ -1,0 +1,187 @@
+if (-not $ENV:BHProjectPath) {
+    Set-BuildEnvironment -Path $PSScriptRoot\..\.. -Force
+}
+Remove-Module PSDeploy -ErrorAction SilentlyContinue
+Import-Module $PSScriptRoot\..\..\PSDeploy\PSDeploy.psd1
+
+InModuleScope 'PSDeploy' {
+    $PSVersion = $PSVersionTable.PSVersion.Major
+    $ProjectRoot = $ENV:BHProjectPath
+
+    # Define path to the deployment script itself
+    $sutPath = "$ProjectRoot\PSDeploy\PSDeployScripts\AzureAutomationDscConfiguration.ps1"
+
+    $Verbose = @{}
+    if ($ENV:BHBranchName -notlike "master" -or $env:BHCommitMessage -match "!verbose") {
+        $Verbose.add("Verbose", $True)
+    }
+
+    Describe "AzureAutomationDscConfigurationScript PS$PSVersion" {
+
+        Context "Code Style" {
+            It "should define CmdletBinding" {
+                $sutPath | Should -FileContentMatch 'CmdletBinding'
+            }
+
+            It "should define parameters" {
+                $sutPath | Should -FileContentMatch 'Param'
+            }
+
+            It "should contain Write-Verbose blocks" {
+                $sutPath | Should -FileContentMatch 'Write-Verbose'
+            }
+
+            It "should be a valid PowerShell code" {
+                $psFile = Get-Content -Path $sutPath -ErrorAction Stop
+                $errors = $null
+                $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
+                $errors.Count | Should -Be 0
+            }
+        }
+
+        Context "Help Quality" {
+
+            # Getting function help
+            $AbstractSyntaxTree = [System.Management.Automation.Language.Parser]::
+            ParseInput((Get-Content -raw $sutPath), [ref]$null, [ref]$null)
+            $AstSearchDelegate = { $args[0] -is [System.Management.Automation.Language.ScriptBlockAst] }
+            $parsedScript = $AbstractSyntaxTree.FindAll( $AstSearchDelegate, $true ) # | Where-Object Name -eq $functionName
+            $scriptHelp = $parsedScript.GetHelpContent()
+
+            It "should have a SYNOPSIS" {
+                $scriptHelp.Synopsis | Should -Not -BeNullOrEmpty
+            }
+
+            It "should have a DESCRIPTION" {
+                $scriptHelp.Description.Length | Should -Not -BeNullOrEmpty
+            }
+
+            It "should have at least one EXAMPLE" {
+                $scriptHelp.Examples.Count | Should -BeGreaterThan 0
+            }
+
+            # Getting the list of function parameters
+            $parameters = $parsedScript.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
+
+            foreach ($parameter in $parameters) {
+                It "should have descriptive help for '$parameter' parameter" {
+                    $scriptHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty
+                    # $scriptHelp.Parameters.($parameter.ToUpper()).Length | Should -BeGreaterThan 15
+                }
+            }
+        }
+
+        Context 'Script Logic' {
+
+            Mock Import-AzAutomationDscConfiguration {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Automation.Model.DscConfiguration</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Commands.Automation.Model.DscConfiguration</ToString>
+        <Props>
+        <S N="ResourceGroupName">AAResourceGroupName</S>
+        <S N="AutomationAccountName">AAName</S>
+        <S N="Location">westeurope</S>
+        <S N="State">Published</S>
+        <S N="Name">MMAConfiguration</S>
+        <Obj N="Tags" RefId="1">
+            <TN RefId="1">
+            <T>System.Collections.Hashtable</T>
+            <T>System.Object</T>
+            </TN>
+            <DCT />
+        </Obj>
+        <Obj N="CreationTime" RefId="2">
+            <TN RefId="2">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>03/22/2020 10:54:46 +02:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-03-22T10:54:46.873</DT>
+            <DT N="UtcDateTime">2020-03-22T08:54:46.873Z</DT>
+            <DT N="LocalDateTime">2020-03-22T10:54:46.873+02:00</DT>
+            <DT N="Date">2020-03-22T00:00:00</DT>
+            <I32 N="Day">22</I32>
+            <S N="DayOfWeek">Sunday</S>
+            <I32 N="DayOfYear">82</I32>
+            <I32 N="Hour">10</I32>
+            <I32 N="Millisecond">873</I32>
+            <I32 N="Minute">54</I32>
+            <I32 N="Month">3</I32>
+            <TS N="Offset">PT2H</TS>
+            <I32 N="Second">46</I32>
+            <I64 N="Ticks">637204712868730000</I64>
+            <I64 N="UtcTicks">637204640868730000</I64>
+            <TS N="TimeOfDay">PT10H54M46.873S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Obj N="LastModifiedTime" RefId="3">
+            <TNRef RefId="2" />
+            <ToString>05/12/2020 09:57:22 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-12T09:57:22.01</DT>
+            <DT N="UtcDateTime">2020-05-12T06:57:22.01Z</DT>
+            <DT N="LocalDateTime">2020-05-12T09:57:22.01+03:00</DT>
+            <DT N="Date">2020-05-12T00:00:00</DT>
+            <I32 N="Day">12</I32>
+            <S N="DayOfWeek">Tuesday</S>
+            <I32 N="DayOfYear">133</I32>
+            <I32 N="Hour">9</I32>
+            <I32 N="Millisecond">10</I32>
+            <I32 N="Minute">57</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">22</I32>
+            <I64 N="Ticks">637248742420100000</I64>
+            <I64 N="UtcTicks">637248634420100000</I64>
+            <TS N="TimeOfDay">PT9H57M22.01S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <S N="Description"></S>
+        <Obj N="Parameters" RefId="4">
+            <TNRef RefId="1" />
+            <DCT />
+        </Obj>
+        <B N="LogVerbose">false</B>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+
+            Mock Start-AzAutomationDscCompilationJob {}
+
+            It 'should import the configuration' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationDscConfiguration.psdeploy.ps1" -Force
+                    Assert-MockCalled Import-AzAutomationDscConfiguration -Times 1 -Exactly
+                }
+            }
+
+            It 'should compile the configuration' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationDscConfiguration.psdeploy.ps1" -Force
+                    Assert-MockCalled Start-AzAutomationDscCompilationJob -Times 1 -Exactly
+                }
+            }
+
+            It "should output into the pipeline" {
+                $result = { Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationDscConfiguration.psdeploy.ps1" -Force }
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}

--- a/Tests/Types/AzureAutomationDscConfiguration.Tests.ps1
+++ b/Tests/Types/AzureAutomationDscConfiguration.Tests.ps1
@@ -166,14 +166,14 @@ InModuleScope 'PSDeploy' {
             It 'should import the configuration' {
                 {
                     Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationDscConfiguration.psdeploy.ps1" -Force
-                    Assert-MockCalled Import-AzAutomationDscConfiguration -Times 1 -Exactly
+                    Assert-MockCalled Import-AzAutomationDscConfiguration -Exactly 1 -Scope It
                 }
             }
 
             It 'should compile the configuration' {
                 {
                     Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationDscConfiguration.psdeploy.ps1" -Force
-                    Assert-MockCalled Start-AzAutomationDscCompilationJob -Times 1 -Exactly
+                    Assert-MockCalled Start-AzAutomationDscCompilationJob -Exactly 1 -Scope It
                 }
             }
 

--- a/Tests/Types/AzureAutomationDscConfiguration.Tests.ps1
+++ b/Tests/Types/AzureAutomationDscConfiguration.Tests.ps1
@@ -61,13 +61,13 @@ InModuleScope 'PSDeploy' {
             }
 
             # Getting the list of function parameters
-            $parameters = $parsedScript.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
+            <# $parameters = $parsedScript.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
 
             foreach ($parameter in $parameters) {
                 It "should have descriptive help for '$parameter' parameter" {
                     $scriptHelp.Parameters.($parameter.ToUpper()) | Should Not BeNullOrEmpty
                 }
-            }
+            } #>
         }
 
         Context 'Script Logic' {

--- a/Tests/Types/AzureAutomationModule.Tests.ps1
+++ b/Tests/Types/AzureAutomationModule.Tests.ps1
@@ -61,13 +61,13 @@ InModuleScope 'PSDeploy' {
             }
 
             # Getting the list of function parameters
-            $parameters = $parsedScript.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
+            <# $parameters = $parsedScript.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
 
             foreach ($parameter in $parameters) {
                 It "should have descriptive help for '$parameter' parameter" {
                     $scriptHelp.Parameters.($parameter.ToUpper()) | Should Not BeNullOrEmpty
                 }
-            }
+            } #>
         }
 
         Context 'Script Logic - Public Module' {

--- a/Tests/Types/AzureAutomationModule.Tests.ps1
+++ b/Tests/Types/AzureAutomationModule.Tests.ps1
@@ -20,22 +20,22 @@ InModuleScope 'PSDeploy' {
 
         Context "Code Style" {
             It "should define CmdletBinding" {
-                $sutPath | Should -FileContentMatch 'CmdletBinding'
+                $sutPath | Should Contain 'CmdletBinding'
             }
 
             It "should define parameters" {
-                $sutPath | Should -FileContentMatch 'Param'
+                $sutPath | Should Contain 'Param'
             }
 
             It "should contain Write-Verbose blocks" {
-                $sutPath | Should -FileContentMatch 'Write-Verbose'
+                $sutPath | Should Contain 'Write-Verbose'
             }
 
             It "should be a valid PowerShell code" {
                 $psFile = Get-Content -Path $sutPath -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
-                $errors.Count | Should -Be 0
+                $errors.Count | Should Be 0
             }
         }
 
@@ -49,15 +49,15 @@ InModuleScope 'PSDeploy' {
             $scriptHelp = $parsedScript.GetHelpContent()
 
             It "should have a SYNOPSIS" {
-                $scriptHelp.Synopsis | Should -Not -BeNullOrEmpty
+                $scriptHelp.Synopsis | Should Not BeNullOrEmpty
             }
 
             It "should have a DESCRIPTION" {
-                $scriptHelp.Description.Length | Should -Not -BeNullOrEmpty
+                $scriptHelp.Description.Length | Should Not BeNullOrEmpty
             }
 
             It "should have at least one EXAMPLE" {
-                $scriptHelp.Examples.Count | Should -BeGreaterThan 0
+                $scriptHelp.Examples.Count | Should BeGreaterThan 0
             }
 
             # Getting the list of function parameters
@@ -65,14 +65,14 @@ InModuleScope 'PSDeploy' {
 
             foreach ($parameter in $parameters) {
                 It "should have descriptive help for '$parameter' parameter" {
-                    $scriptHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty
+                    $scriptHelp.Parameters.($parameter.ToUpper()) | Should Not BeNullOrEmpty
                 }
             }
         }
 
         Context 'Script Logic - Public Module' {
 
-            Mock -ModuleName 'Az.Automation' Get-AzAutomationAccount {
+            Mock Get-AzAutomationAccount {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -161,7 +161,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Automation' Get-AzAutomationModule {
+            Mock Get-AzAutomationModule {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -239,7 +239,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Automation' New-AzAutomationModule {
+            Mock New-AzAutomationModule {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -318,13 +318,13 @@ InModuleScope 'PSDeploy' {
                 $data
             }
 
-            Mock -ModuleName 'Az.Storage' Get-AzStorageAccount {}
-            Mock -ModuleName 'Az.Storage' Get-AzStorageContainer {}
-            Mock -ModuleName 'Az.Storage' Get-AzStorageAccountKey {}
-            Mock -ModuleName 'Az.Storage' New-AzStorageContainer {}
-            Mock -ModuleName 'Az.Storage' New-AzStorageContext {}
-            Mock -ModuleName 'Az.Storage' New-AzStorageBlobSASToken {}
-            Mock -ModuleName 'Az.Storage' Set-AzStorageBlobContent {}
+            Mock Get-AzStorageAccount {}
+            Mock Get-AzStorageContainer {}
+            Mock Get-AzStorageAccountKey {}
+            Mock New-AzStorageContainer {}
+            Mock New-AzStorageContext {}
+            Mock New-AzStorageBlobSASToken {}
+            Mock Set-AzStorageBlobContent {}
 
             It 'should get an Automation account' {
                 {
@@ -363,7 +363,7 @@ InModuleScope 'PSDeploy' {
 
         Context 'Script Logic - Private Module' {
 
-            Mock -ModuleName 'Az.Automation' Get-AzAutomationAccount {
+            Mock Get-AzAutomationAccount {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -452,7 +452,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Automation' Get-AzAutomationModule {
+            Mock Get-AzAutomationModule {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -530,7 +530,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Automation' New-AzAutomationModule {
+            Mock New-AzAutomationModule {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -608,7 +608,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' Get-AzStorageAccount {
+            Mock Get-AzStorageAccount {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -788,7 +788,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' Get-AzStorageContainer {
+            Mock Get-AzStorageContainer {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -946,7 +946,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' Get-AzStorageAccountKey {
+            Mock Get-AzStorageAccountKey {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -991,7 +991,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' New-AzStorageContainer {
+            Mock New-AzStorageContainer {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -1149,7 +1149,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' New-AzStorageContext {
+            Mock New-AzStorageContext {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -1234,7 +1234,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' New-AzStorageBlobSASToken {
+            Mock New-AzStorageBlobSASToken {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -1246,7 +1246,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' Set-AzStorageBlobContent {
+            Mock Set-AzStorageBlobContent {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -1466,7 +1466,7 @@ InModuleScope 'PSDeploy' {
 
         Context 'Script Logic - Source Module' {
 
-            Mock -ModuleName 'Az.Automation' Get-AzAutomationAccount {
+            Mock Get-AzAutomationAccount {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -1555,7 +1555,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Automation' Get-AzAutomationModule {
+            Mock Get-AzAutomationModule {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -1633,7 +1633,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Automation' New-AzAutomationModule {
+            Mock New-AzAutomationModule {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -1711,7 +1711,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' Get-AzStorageAccount {
+            Mock Get-AzStorageAccount {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -1891,7 +1891,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' Get-AzStorageContainer {
+            Mock Get-AzStorageContainer {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -2049,7 +2049,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' Get-AzStorageAccountKey {
+            Mock Get-AzStorageAccountKey {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -2094,7 +2094,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' New-AzStorageContainer {
+            Mock New-AzStorageContainer {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -2252,7 +2252,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' New-AzStorageContext {
+            Mock New-AzStorageContext {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -2337,7 +2337,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' New-AzStorageBlobSASToken {
+            Mock New-AzStorageBlobSASToken {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
@@ -2349,7 +2349,7 @@ InModuleScope 'PSDeploy' {
                 $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
                 $data
             }
-            Mock -ModuleName 'Az.Storage' Set-AzStorageBlobContent {
+            Mock Set-AzStorageBlobContent {
                 #region MockData
                 $mockedSerializedData = @'
 <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">

--- a/Tests/Types/AzureAutomationModule.Tests.ps1
+++ b/Tests/Types/AzureAutomationModule.Tests.ps1
@@ -1,0 +1,2570 @@
+if (-not $ENV:BHProjectPath) {
+    Set-BuildEnvironment -Path $PSScriptRoot\..\.. -Force
+}
+Remove-Module PSDeploy -ErrorAction SilentlyContinue
+Import-Module $PSScriptRoot\..\..\PSDeploy\PSDeploy.psd1
+
+InModuleScope 'PSDeploy' {
+    $PSVersion = $PSVersionTable.PSVersion.Major
+    $ProjectRoot = $ENV:BHProjectPath
+
+    # Define path to the deployment script itself
+    $sutPath = "$ProjectRoot\PSDeploy\PSDeployScripts\AzureAutomationModule.ps1"
+
+    $Verbose = @{}
+    if ($ENV:BHBranchName -notlike "master" -or $env:BHCommitMessage -match "!verbose") {
+        $Verbose.add("Verbose", $True)
+    }
+
+    Describe "AzureAutomationModuleScript PS$PSVersion" {
+
+        Context "Code Style" {
+            It "should define CmdletBinding" {
+                $sutPath | Should -FileContentMatch 'CmdletBinding'
+            }
+
+            It "should define parameters" {
+                $sutPath | Should -FileContentMatch 'Param'
+            }
+
+            It "should contain Write-Verbose blocks" {
+                $sutPath | Should -FileContentMatch 'Write-Verbose'
+            }
+
+            It "should be a valid PowerShell code" {
+                $psFile = Get-Content -Path $sutPath -ErrorAction Stop
+                $errors = $null
+                $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
+                $errors.Count | Should -Be 0
+            }
+        }
+
+        Context "Help Quality" {
+
+            # Getting function help
+            $AbstractSyntaxTree = [System.Management.Automation.Language.Parser]::
+            ParseInput((Get-Content -raw $sutPath), [ref]$null, [ref]$null)
+            $AstSearchDelegate = { $args[0] -is [System.Management.Automation.Language.ScriptBlockAst] }
+            $parsedScript = $AbstractSyntaxTree.FindAll( $AstSearchDelegate, $true ) # | Where-Object Name -eq $functionName
+            $scriptHelp = $parsedScript.GetHelpContent()
+
+            It "should have a SYNOPSIS" {
+                $scriptHelp.Synopsis | Should -Not -BeNullOrEmpty
+            }
+
+            It "should have a DESCRIPTION" {
+                $scriptHelp.Description.Length | Should -Not -BeNullOrEmpty
+            }
+
+            It "should have at least one EXAMPLE" {
+                $scriptHelp.Examples.Count | Should -BeGreaterThan 0
+            }
+
+            # Getting the list of function parameters
+            $parameters = $parsedScript.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
+
+            foreach ($parameter in $parameters) {
+                It "should have descriptive help for '$parameter' parameter" {
+                    $scriptHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty
+                }
+            }
+        }
+
+        Context 'Script Logic - Public Module' {
+
+            Mock -ModuleName 'Az.Automation' Get-AzAutomationAccount {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Automation.Model.AutomationAccount</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Commands.Automation.Model.AutomationAccount</ToString>
+        <Props>
+        <S N="SubscriptionId">c49124fa-befd-4207-a3b7-29c95c41a964</S>
+        <S N="ResourceGroupName">AAResourceGroupName</S>
+        <S N="AutomationAccountName">AAName</S>
+        <S N="Location">westeurope</S>
+        <S N="State">Ok</S>
+        <S N="Plan">Basic</S>
+        <Obj N="CreationTime" RefId="1">
+            <TN RefId="1">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>10/02/2017 16:05:15 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2017-10-02T16:05:15.39</DT>
+            <DT N="UtcDateTime">2017-10-02T13:05:15.39Z</DT>
+            <DT N="LocalDateTime">2017-10-02T16:05:15.39+03:00</DT>
+            <DT N="Date">2017-10-02T00:00:00</DT>
+            <I32 N="Day">2</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">275</I32>
+            <I32 N="Hour">16</I32>
+            <I32 N="Millisecond">390</I32>
+            <I32 N="Minute">5</I32>
+            <I32 N="Month">10</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">15</I32>
+            <I64 N="Ticks">636425571153900000</I64>
+            <I64 N="UtcTicks">636425463153900000</I64>
+            <TS N="TimeOfDay">PT16H5M15.39S</TS>
+            <I32 N="Year">2017</I32>
+            </Props>
+        </Obj>
+        <Obj N="LastModifiedTime" RefId="2">
+            <TNRef RefId="1" />
+            <ToString>03/22/2020 10:41:20 +02:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-03-22T10:41:20.57</DT>
+            <DT N="UtcDateTime">2020-03-22T08:41:20.57Z</DT>
+            <DT N="LocalDateTime">2020-03-22T10:41:20.57+02:00</DT>
+            <DT N="Date">2020-03-22T00:00:00</DT>
+            <I32 N="Day">22</I32>
+            <S N="DayOfWeek">Sunday</S>
+            <I32 N="DayOfYear">82</I32>
+            <I32 N="Hour">10</I32>
+            <I32 N="Millisecond">570</I32>
+            <I32 N="Minute">41</I32>
+            <I32 N="Month">3</I32>
+            <TS N="Offset">PT2H</TS>
+            <I32 N="Second">20</I32>
+            <I64 N="Ticks">637204704805700000</I64>
+            <I64 N="UtcTicks">637204632805700000</I64>
+            <TS N="TimeOfDay">PT10H41M20.57S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Nil N="LastModifiedBy" />
+        <Obj N="Tags" RefId="3">
+            <TN RefId="2">
+            <T>System.Collections.Hashtable</T>
+            <T>System.Object</T>
+            </TN>
+            <DCT>
+            <En>
+                <S N="Key">environment</S>
+                <S N="Value">Test</S>
+            </En>
+            </DCT>
+        </Obj>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Automation' Get-AzAutomationModule {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Automation.Model.Module</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Commands.Automation.Model.Module</ToString>
+        <Props>
+        <S N="ResourceGroupName">AAResourceGroupName</S>
+        <S N="AutomationAccountName">AANAme</S>
+        <S N="Name">PSDepend</S>
+        <B N="IsGlobal">false</B>
+        <S N="Version">0.3.2</S>
+        <I64 N="SizeInBytes">71093</I64>
+        <I32 N="ActivityCount">8</I32>
+        <Obj N="CreationTime" RefId="1">
+            <TN RefId="1">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/04/2020 17:42:32 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T17:42:32.617</DT>
+            <DT N="UtcDateTime">2020-05-04T14:42:32.617Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:42:32.617+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">17</I32>
+            <I32 N="Millisecond">617</I32>
+            <I32 N="Minute">42</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">32</I32>
+            <I64 N="Ticks">637242109526170000</I64>
+            <I64 N="UtcTicks">637242001526170000</I64>
+            <TS N="TimeOfDay">PT17H42M32.617S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Obj N="LastModifiedTime" RefId="2">
+            <TNRef RefId="1" />
+            <ToString>05/04/2020 17:44:14 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T17:44:14.537</DT>
+            <DT N="UtcDateTime">2020-05-04T14:44:14.537Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:44:14.537+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">17</I32>
+            <I32 N="Millisecond">537</I32>
+            <I32 N="Minute">44</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">14</I32>
+            <I64 N="Ticks">637242110545370000</I64>
+            <I64 N="UtcTicks">637242002545370000</I64>
+            <TS N="TimeOfDay">PT17H44M14.537S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <S N="ProvisioningState">Succeeded</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Automation' New-AzAutomationModule {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Automation.Model.Module</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Commands.Automation.Model.Module</ToString>
+        <Props>
+        <S N="ResourceGroupName">AAResourceGroupName</S>
+        <S N="AutomationAccountName">AAName</S>
+        <S N="Name">PSDepend</S>
+        <B N="IsGlobal">false</B>
+        <S N="Version">0.3.2</S>
+        <I64 N="SizeInBytes">71093</I64>
+        <I32 N="ActivityCount">8</I32>
+        <Obj N="CreationTime" RefId="1">
+            <TN RefId="1">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/04/2020 17:42:32 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T17:42:32.617</DT>
+            <DT N="UtcDateTime">2020-05-04T14:42:32.617Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:42:32.617+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">17</I32>
+            <I32 N="Millisecond">617</I32>
+            <I32 N="Minute">42</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">32</I32>
+            <I64 N="Ticks">637242109526170000</I64>
+            <I64 N="UtcTicks">637242001526170000</I64>
+            <TS N="TimeOfDay">PT17H42M32.617S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Obj N="LastModifiedTime" RefId="2">
+            <TNRef RefId="1" />
+            <ToString>05/12/2020 14:05:27 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-12T14:05:27.527</DT>
+            <DT N="UtcDateTime">2020-05-12T11:05:27.527Z</DT>
+            <DT N="LocalDateTime">2020-05-12T14:05:27.527+03:00</DT>
+            <DT N="Date">2020-05-12T00:00:00</DT>
+            <I32 N="Day">12</I32>
+            <S N="DayOfWeek">Tuesday</S>
+            <I32 N="DayOfYear">133</I32>
+            <I32 N="Hour">14</I32>
+            <I32 N="Millisecond">527</I32>
+            <I32 N="Minute">5</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">27</I32>
+            <I64 N="Ticks">637248891275270000</I64>
+            <I64 N="UtcTicks">637248783275270000</I64>
+            <TS N="TimeOfDay">PT14H5M27.527S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <S N="ProvisioningState">Succeeded</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+
+            Mock -ModuleName 'Az.Storage' Get-AzStorageAccount {}
+            Mock -ModuleName 'Az.Storage' Get-AzStorageContainer {}
+            Mock -ModuleName 'Az.Storage' Get-AzStorageAccountKey {}
+            Mock -ModuleName 'Az.Storage' New-AzStorageContainer {}
+            Mock -ModuleName 'Az.Storage' New-AzStorageContext {}
+            Mock -ModuleName 'Az.Storage' New-AzStorageBlobSASToken {}
+            Mock -ModuleName 'Az.Storage' Set-AzStorageBlobContent {}
+
+            It 'should get an Automation account' {
+                {
+                    {Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force}
+                    Assert-MockCalled Get-AzAutomationAccount -Exactly 1 -Scope It
+                }
+            }
+
+            It 'should query the Automation account for already imported module' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force
+                    Assert-MockCalled Get-AzAutomationModule -Exactly 1 -Scope It
+                }
+            }
+
+            It 'should import the module into Automation account' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force
+                    Assert-MockCalled New-AzAutomationModule -Exactly 1 -Scope It
+                }
+            }
+
+            It 'should should not use a Storage account' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force
+                    Assert-MockCalled Get-AzStorageAccount -Exactly 0 -Scope It
+                    Assert-MockCalled Get-AzStorageContainer -Exactly 0 -Scope It
+                    Assert-MockCalled Get-AzStorageAccountKey -Exactly 0 -Scope It
+                    Assert-MockCalled New-AzStorageContainer -Exactly 0 -Scope It
+                    Assert-MockCalled New-AzStorageContext -Exactly 0 -Scope It
+                    Assert-MockCalled New-AzStorageBlobSASToken -Exactly 0 -Scope It
+                    Assert-MockCalled Set-AzStorageBlobContent -Exactly 0 -Scope It
+                }
+            }
+        }
+
+        Context 'Script Logic - Private Module' {
+
+            Mock -ModuleName 'Az.Automation' Get-AzAutomationAccount {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Automation.Model.AutomationAccount</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Commands.Automation.Model.AutomationAccount</ToString>
+        <Props>
+        <S N="SubscriptionId">c49124fa-befd-4207-a3b7-29c95c41a964</S>
+        <S N="ResourceGroupName">AAResourceGroupName</S>
+        <S N="AutomationAccountName">AAName</S>
+        <S N="Location">westeurope</S>
+        <S N="State">Ok</S>
+        <S N="Plan">Basic</S>
+        <Obj N="CreationTime" RefId="1">
+            <TN RefId="1">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>10/02/2017 16:05:15 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2017-10-02T16:05:15.39</DT>
+            <DT N="UtcDateTime">2017-10-02T13:05:15.39Z</DT>
+            <DT N="LocalDateTime">2017-10-02T16:05:15.39+03:00</DT>
+            <DT N="Date">2017-10-02T00:00:00</DT>
+            <I32 N="Day">2</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">275</I32>
+            <I32 N="Hour">16</I32>
+            <I32 N="Millisecond">390</I32>
+            <I32 N="Minute">5</I32>
+            <I32 N="Month">10</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">15</I32>
+            <I64 N="Ticks">636425571153900000</I64>
+            <I64 N="UtcTicks">636425463153900000</I64>
+            <TS N="TimeOfDay">PT16H5M15.39S</TS>
+            <I32 N="Year">2017</I32>
+            </Props>
+        </Obj>
+        <Obj N="LastModifiedTime" RefId="2">
+            <TNRef RefId="1" />
+            <ToString>03/22/2020 10:41:20 +02:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-03-22T10:41:20.57</DT>
+            <DT N="UtcDateTime">2020-03-22T08:41:20.57Z</DT>
+            <DT N="LocalDateTime">2020-03-22T10:41:20.57+02:00</DT>
+            <DT N="Date">2020-03-22T00:00:00</DT>
+            <I32 N="Day">22</I32>
+            <S N="DayOfWeek">Sunday</S>
+            <I32 N="DayOfYear">82</I32>
+            <I32 N="Hour">10</I32>
+            <I32 N="Millisecond">570</I32>
+            <I32 N="Minute">41</I32>
+            <I32 N="Month">3</I32>
+            <TS N="Offset">PT2H</TS>
+            <I32 N="Second">20</I32>
+            <I64 N="Ticks">637204704805700000</I64>
+            <I64 N="UtcTicks">637204632805700000</I64>
+            <TS N="TimeOfDay">PT10H41M20.57S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Nil N="LastModifiedBy" />
+        <Obj N="Tags" RefId="3">
+            <TN RefId="2">
+            <T>System.Collections.Hashtable</T>
+            <T>System.Object</T>
+            </TN>
+            <DCT>
+            <En>
+                <S N="Key">environment</S>
+                <S N="Value">Test</S>
+            </En>
+            </DCT>
+        </Obj>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Automation' Get-AzAutomationModule {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Automation.Model.Module</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Commands.Automation.Model.Module</ToString>
+        <Props>
+        <S N="ResourceGroupName">AAResourceGroupName</S>
+        <S N="AutomationAccountName">AANAme</S>
+        <S N="Name">PSDepend</S>
+        <B N="IsGlobal">false</B>
+        <S N="Version">0.3.2</S>
+        <I64 N="SizeInBytes">71093</I64>
+        <I32 N="ActivityCount">8</I32>
+        <Obj N="CreationTime" RefId="1">
+            <TN RefId="1">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/04/2020 17:42:32 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T17:42:32.617</DT>
+            <DT N="UtcDateTime">2020-05-04T14:42:32.617Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:42:32.617+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">17</I32>
+            <I32 N="Millisecond">617</I32>
+            <I32 N="Minute">42</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">32</I32>
+            <I64 N="Ticks">637242109526170000</I64>
+            <I64 N="UtcTicks">637242001526170000</I64>
+            <TS N="TimeOfDay">PT17H42M32.617S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Obj N="LastModifiedTime" RefId="2">
+            <TNRef RefId="1" />
+            <ToString>05/04/2020 17:44:14 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T17:44:14.537</DT>
+            <DT N="UtcDateTime">2020-05-04T14:44:14.537Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:44:14.537+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">17</I32>
+            <I32 N="Millisecond">537</I32>
+            <I32 N="Minute">44</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">14</I32>
+            <I64 N="Ticks">637242110545370000</I64>
+            <I64 N="UtcTicks">637242002545370000</I64>
+            <TS N="TimeOfDay">PT17H44M14.537S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <S N="ProvisioningState">Succeeded</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Automation' New-AzAutomationModule {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Automation.Model.Module</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Commands.Automation.Model.Module</ToString>
+        <Props>
+        <S N="ResourceGroupName">AAResourceGroupName</S>
+        <S N="AutomationAccountName">AAName</S>
+        <S N="Name">PSDepend</S>
+        <B N="IsGlobal">false</B>
+        <S N="Version">0.3.2</S>
+        <I64 N="SizeInBytes">71093</I64>
+        <I32 N="ActivityCount">8</I32>
+        <Obj N="CreationTime" RefId="1">
+            <TN RefId="1">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/04/2020 17:42:32 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T17:42:32.617</DT>
+            <DT N="UtcDateTime">2020-05-04T14:42:32.617Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:42:32.617+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">17</I32>
+            <I32 N="Millisecond">617</I32>
+            <I32 N="Minute">42</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">32</I32>
+            <I64 N="Ticks">637242109526170000</I64>
+            <I64 N="UtcTicks">637242001526170000</I64>
+            <TS N="TimeOfDay">PT17H42M32.617S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Obj N="LastModifiedTime" RefId="2">
+            <TNRef RefId="1" />
+            <ToString>05/12/2020 14:05:27 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-12T14:05:27.527</DT>
+            <DT N="UtcDateTime">2020-05-12T11:05:27.527Z</DT>
+            <DT N="LocalDateTime">2020-05-12T14:05:27.527+03:00</DT>
+            <DT N="Date">2020-05-12T00:00:00</DT>
+            <I32 N="Day">12</I32>
+            <S N="DayOfWeek">Tuesday</S>
+            <I32 N="DayOfYear">133</I32>
+            <I32 N="Hour">14</I32>
+            <I32 N="Millisecond">527</I32>
+            <I32 N="Minute">5</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">27</I32>
+            <I64 N="Ticks">637248891275270000</I64>
+            <I64 N="UtcTicks">637248783275270000</I64>
+            <TS N="TimeOfDay">PT14H5M27.527S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <S N="ProvisioningState">Succeeded</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' Get-AzStorageAccount {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Management.Storage.Models.PSStorageAccount</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString />
+        <Props>
+        <S N="ResourceGroupName">SATestAutomationAndMonitoringRG</S>
+        <S N="StorageAccountName">aadeploymentstor</S>
+        <S N="Id">/subscriptions/eb31e8d0-5a14-4eea-87b9-66581523e545/resourceGroups/SATestAutomationAndMonitoringRG/providers/Microsoft.Storage/storageAccounts/aadeploymentstor</S>
+        <S N="Location">westeurope</S>
+        <Obj N="Sku" RefId="1">
+            <TN RefId="1">
+            <T>Microsoft.Azure.Commands.Management.Storage.Models.PSSku</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Commands.Management.Storage.Models.PSSku</ToString>
+            <Props>
+            <S N="Name">Standard_LRS</S>
+            <S N="Tier">Standard</S>
+            <Nil N="ResourceType" />
+            <Nil N="Kind" />
+            <Nil N="Locations" />
+            <Nil N="Capabilities" />
+            <Nil N="Restrictions" />
+            </Props>
+        </Obj>
+        <S N="Kind">StorageV2</S>
+        <Obj N="Encryption" RefId="2">
+            <TN RefId="2">
+            <T>Microsoft.Azure.Management.Storage.Models.Encryption</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Management.Storage.Models.Encryption</ToString>
+            <Props>
+            <S N="Services">Microsoft.Azure.Management.Storage.Models.EncryptionServices</S>
+            <S N="KeySource">Microsoft.Storage</S>
+            <Nil N="KeyVaultProperties" />
+            </Props>
+        </Obj>
+        <Obj N="AccessTier" RefId="3">
+            <TN RefId="3">
+            <T>Microsoft.Azure.Management.Storage.Models.AccessTier</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Hot</ToString>
+            <I32>0</I32>
+        </Obj>
+        <DT N="CreationTime">2020-05-03T10:59:39.4378401Z</DT>
+        <Nil N="CustomDomain" />
+        <Nil N="Identity" />
+        <Nil N="LastGeoFailoverTime" />
+        <Obj N="PrimaryEndpoints" RefId="4">
+            <TN RefId="4">
+            <T>Microsoft.Azure.Management.Storage.Models.Endpoints</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Management.Storage.Models.Endpoints</ToString>
+            <Props>
+            <S N="Blob">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="Queue">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="Table">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="File">https://aadeploymentstor.file.core.windows.net/</S>
+            <S N="Web">https://aadeploymentstor.z6.web.core.windows.net/</S>
+            <S N="Dfs">https://aadeploymentstor.dfs.core.windows.net/</S>
+            <Nil N="MicrosoftEndpoints" />
+            <Nil N="InternetEndpoints" />
+            </Props>
+        </Obj>
+        <S N="PrimaryLocation">westeurope</S>
+        <Obj N="ProvisioningState" RefId="5">
+            <TN RefId="5">
+            <T>Microsoft.Azure.Management.Storage.Models.ProvisioningState</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Succeeded</ToString>
+            <I32>2</I32>
+        </Obj>
+        <Nil N="SecondaryEndpoints" />
+        <Nil N="SecondaryLocation" />
+        <Obj N="StatusOfPrimary" RefId="6">
+            <TN RefId="6">
+            <T>Microsoft.Azure.Management.Storage.Models.AccountStatus</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Available</ToString>
+            <I32>0</I32>
+        </Obj>
+        <Nil N="StatusOfSecondary" />
+        <Obj N="Tags" RefId="7">
+            <TN RefId="7">
+            <T>System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</T>
+            <T>System.Object</T>
+            </TN>
+            <DCT>
+            <En>
+                <S N="Key">environment</S>
+                <S N="Value">Test</S>
+            </En>
+            </DCT>
+        </Obj>
+        <B N="EnableHttpsTrafficOnly">true</B>
+        <Nil N="AzureFilesIdentityBasedAuth" />
+        <Nil N="EnableHierarchicalNamespace" />
+        <S N="LargeFileSharesState">Disabled</S>
+        <Obj N="NetworkRuleSet" RefId="8">
+            <TN RefId="8">
+            <T>Microsoft.Azure.Commands.Management.Storage.Models.PSNetworkRuleSet</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Commands.Management.Storage.Models.PSNetworkRuleSet</ToString>
+            <Props>
+            <Obj N="IpRules" RefId="9">
+                <TN RefId="9">
+                <T>Microsoft.Azure.Commands.Management.Storage.Models.PSIpRule[]</T>
+                <T>System.Array</T>
+                <T>System.Object</T>
+                </TN>
+                <LST />
+            </Obj>
+            <Obj N="VirtualNetworkRules" RefId="10">
+                <TN RefId="10">
+                <T>Microsoft.Azure.Commands.Management.Storage.Models.PSVirtualNetworkRule[]</T>
+                <T>System.Array</T>
+                <T>System.Object</T>
+                </TN>
+                <LST />
+            </Obj>
+            <S N="Bypass">AzureServices</S>
+            <S N="DefaultAction">Allow</S>
+            </Props>
+        </Obj>
+        <Nil N="GeoReplicationStats" />
+        <Obj N="Context" RefId="11">
+            <TN RefId="11">
+            <T>Microsoft.WindowsAzure.Commands.Common.Storage.LazyAzureStorageContext</T>
+            <T>Microsoft.WindowsAzure.Commands.Common.Storage.AzureStorageContext</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.WindowsAzure.Commands.Common.Storage.LazyAzureStorageContext</ToString>
+            <Props>
+            <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+            <S N="StorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=[key hidden]</S>
+            <S N="StorageAccountName">aadeploymentstor</S>
+            <Ref N="Context" RefId="11" />
+            <S N="Name">aadeploymentstor</S>
+            <S N="EndPointSuffix">core.windows.net/</S>
+            <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+            <Obj N="ExtendedProperties" RefId="12">
+                <TNRef RefId="7" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <Obj N="ExtendedProperties" RefId="13">
+            <TNRef RefId="7" />
+            <DCT />
+        </Obj>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' Get-AzStorageContainer {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageContainer</T>
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageBase</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageContainer</ToString>
+        <Props>
+        <Obj N="CloudBlobContainer" RefId="1">
+            <TN RefId="1">
+            <T>Microsoft.Azure.Storage.Blob.CloudBlobContainer</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Storage.Blob.CloudBlobContainer</ToString>
+            <Props>
+            <S N="ServiceClient">Microsoft.Azure.Storage.Blob.CloudBlobClient</S>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend</URI>
+            <S N="StorageUri">Primary = 'https://aadeploymentstor.blob.core.windows.net/psdepend'; Secondary = ''</S>
+            <S N="Name">psdepend</S>
+            <Obj N="Metadata" RefId="2">
+                <TN RefId="2">
+                <T>System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</T>
+                <T>System.Object</T>
+                </TN>
+                <DCT />
+            </Obj>
+            <S N="Properties">Microsoft.Azure.Storage.Blob.BlobContainerProperties</S>
+            </Props>
+        </Obj>
+        <Obj N="Permission" RefId="3">
+            <TN RefId="3">
+            <T>Microsoft.Azure.Storage.Blob.BlobContainerPermissions</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Storage.Blob.BlobContainerPermissions</ToString>
+            <Props>
+            <S N="PublicAccess">Container</S>
+            <Obj N="SharedAccessPolicies" RefId="4">
+                <TN RefId="4">
+                <T>Microsoft.Azure.Storage.Blob.SharedAccessBlobPolicies</T>
+                <T>System.Object</T>
+                </TN>
+                <IE />
+            </Obj>
+            </Props>
+        </Obj>
+        <Obj N="PublicAccess" RefId="5">
+            <TN RefId="5">
+            <T>Microsoft.Azure.Storage.Blob.BlobContainerPublicAccessType</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Container</ToString>
+            <I32>1</I32>
+        </Obj>
+        <Obj N="LastModified" RefId="6">
+            <TN RefId="6">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/04/2020 14:45:45 +00:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T14:45:45</DT>
+            <DT N="UtcDateTime">2020-05-04T14:45:45Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:45:45+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">14</I32>
+            <I32 N="Millisecond">0</I32>
+            <I32 N="Minute">45</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT0S</TS>
+            <I32 N="Second">45</I32>
+            <I64 N="Ticks">637242003450000000</I64>
+            <I64 N="UtcTicks">637242003450000000</I64>
+            <TS N="TimeOfDay">PT14H45M45S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Nil N="ContinuationToken" />
+        <Obj N="BlobContainerClient" RefId="7">
+            <TN RefId="7">
+            <T>Azure.Storage.Blobs.BlobContainerClient</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.BlobContainerClient</ToString>
+            <Props>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend</URI>
+            <S N="AccountName">aadeploymentstor</S>
+            <S N="Name">psdepend</S>
+            </Props>
+        </Obj>
+        <Obj N="BlobContainerProperties" RefId="8">
+            <TN RefId="8">
+            <T>Azure.Storage.Blobs.Models.BlobContainerProperties</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.Models.BlobContainerProperties</ToString>
+            <Props>
+            <S N="LastModified">05/04/2020 14:45:45 +00:00</S>
+            <S N="LeaseStatus">Unlocked</S>
+            <S N="LeaseState">Available</S>
+            <S N="LeaseDuration">Infinite</S>
+            <S N="PublicAccess">BlobContainer</S>
+            <B N="HasImmutabilityPolicy">false</B>
+            <B N="HasLegalHold">false</B>
+            <S N="DefaultEncryptionScope">$account-encryption-key</S>
+            <B N="PreventEncryptionScopeOverride">false</B>
+            <S N="ETag">"0x8D7F039D3D0C5C5"</S>
+            <Obj N="Metadata" RefId="9">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <Obj N="Context" RefId="10">
+            <TN RefId="9">
+            <T>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</ToString>
+            <Props>
+            <S N="StorageAccountName">aadeploymentstor</S>
+            <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+            <Ref N="Context" RefId="10" />
+            <S N="Name"></S>
+            <S N="StorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https;AccountName=aadeploymentstor;AccountKey=[key hidden]</S>
+            <S N="TableStorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https</S>
+            <Nil N="Track2OauthToken" />
+            <S N="EndPointSuffix">core.windows.net/</S>
+            <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+            <Obj N="ExtendedProperties" RefId="11">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <S N="Name">psdepend</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' Get-AzStorageAccountKey {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Management.Storage.Models.StorageAccountKey</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Management.Storage.Models.StorageAccountKey</ToString>
+        <Props>
+        <S N="KeyName">key1</S>
+        <S N="Value">aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+        <Obj N="Permissions" RefId="1">
+            <TN RefId="1">
+            <T>Microsoft.Azure.Management.Storage.Models.KeyPermission</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Full</ToString>
+            <I32>1</I32>
+        </Obj>
+        </Props>
+    </Obj>
+    <Obj RefId="2">
+        <TNRef RefId="0" />
+        <ToString>Microsoft.Azure.Management.Storage.Models.StorageAccountKey</ToString>
+        <Props>
+        <S N="KeyName">key2</S>
+        <S N="Value">lCvSampwF8ZkAgjaDJXpw3akynx5aEecS3Wg/WDeygQd7l+/bXMZD+uk0Dd0Jbk2tZ7nBO39W0fGXsZBQtK0zQ==</S>
+        <Obj N="Permissions" RefId="3">
+            <TNRef RefId="1" />
+            <ToString>Full</ToString>
+            <I32>1</I32>
+        </Obj>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' New-AzStorageContainer {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageContainer</T>
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageBase</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageContainer</ToString>
+        <Props>
+        <Obj N="CloudBlobContainer" RefId="1">
+            <TN RefId="1">
+            <T>Microsoft.Azure.Storage.Blob.CloudBlobContainer</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Storage.Blob.CloudBlobContainer</ToString>
+            <Props>
+            <S N="ServiceClient">Microsoft.Azure.Storage.Blob.CloudBlobClient</S>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend</URI>
+            <S N="StorageUri">Primary = 'https://aadeploymentstor.blob.core.windows.net/psdepend'; Secondary = ''</S>
+            <S N="Name">psdepend</S>
+            <Obj N="Metadata" RefId="2">
+                <TN RefId="2">
+                <T>System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</T>
+                <T>System.Object</T>
+                </TN>
+                <DCT />
+            </Obj>
+            <S N="Properties">Microsoft.Azure.Storage.Blob.BlobContainerProperties</S>
+            </Props>
+        </Obj>
+        <Obj N="Permission" RefId="3">
+            <TN RefId="3">
+            <T>Microsoft.Azure.Storage.Blob.BlobContainerPermissions</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Storage.Blob.BlobContainerPermissions</ToString>
+            <Props>
+            <S N="PublicAccess">Container</S>
+            <Obj N="SharedAccessPolicies" RefId="4">
+                <TN RefId="4">
+                <T>Microsoft.Azure.Storage.Blob.SharedAccessBlobPolicies</T>
+                <T>System.Object</T>
+                </TN>
+                <IE />
+            </Obj>
+            </Props>
+        </Obj>
+        <Obj N="PublicAccess" RefId="5">
+            <TN RefId="5">
+            <T>Microsoft.Azure.Storage.Blob.BlobContainerPublicAccessType</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Container</ToString>
+            <I32>1</I32>
+        </Obj>
+        <Obj N="LastModified" RefId="6">
+            <TN RefId="6">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/04/2020 14:45:45 +00:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T14:45:45</DT>
+            <DT N="UtcDateTime">2020-05-04T14:45:45Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:45:45+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">14</I32>
+            <I32 N="Millisecond">0</I32>
+            <I32 N="Minute">45</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT0S</TS>
+            <I32 N="Second">45</I32>
+            <I64 N="Ticks">637242003450000000</I64>
+            <I64 N="UtcTicks">637242003450000000</I64>
+            <TS N="TimeOfDay">PT14H45M45S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Nil N="ContinuationToken" />
+        <Obj N="BlobContainerClient" RefId="7">
+            <TN RefId="7">
+            <T>Azure.Storage.Blobs.BlobContainerClient</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.BlobContainerClient</ToString>
+            <Props>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend</URI>
+            <S N="AccountName">aadeploymentstor</S>
+            <S N="Name">psdepend</S>
+            </Props>
+        </Obj>
+        <Obj N="BlobContainerProperties" RefId="8">
+            <TN RefId="8">
+            <T>Azure.Storage.Blobs.Models.BlobContainerProperties</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.Models.BlobContainerProperties</ToString>
+            <Props>
+            <S N="LastModified">05/04/2020 14:45:45 +00:00</S>
+            <S N="LeaseStatus">Unlocked</S>
+            <S N="LeaseState">Available</S>
+            <S N="LeaseDuration">Infinite</S>
+            <S N="PublicAccess">BlobContainer</S>
+            <B N="HasImmutabilityPolicy">false</B>
+            <B N="HasLegalHold">false</B>
+            <S N="DefaultEncryptionScope">$account-encryption-key</S>
+            <B N="PreventEncryptionScopeOverride">false</B>
+            <S N="ETag">"0x8D7F039D3D0C5C5"</S>
+            <Obj N="Metadata" RefId="9">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <Obj N="Context" RefId="10">
+            <TN RefId="9">
+            <T>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</ToString>
+            <Props>
+            <S N="StorageAccountName">aadeploymentstor</S>
+            <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+            <Ref N="Context" RefId="10" />
+            <S N="Name"></S>
+            <S N="StorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https;AccountName=aadeploymentstor;AccountKey=[key hidden]</S>
+            <S N="TableStorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https</S>
+            <Nil N="Track2OauthToken" />
+            <S N="EndPointSuffix">core.windows.net/</S>
+            <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+            <Obj N="ExtendedProperties" RefId="11">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <S N="Name">psdepend</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' New-AzStorageContext {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</ToString>
+        <Props>
+        <S N="StorageAccountName">aadeploymentstor</S>
+        <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+        <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+        <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+        <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+        <Obj N="Context" RefId="1">
+            <TNRef RefId="0" />
+            <ToString>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</ToString>
+            <Props>
+            <S N="StorageAccountName">aadeploymentstor</S>
+            <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+            <Ref N="Context" RefId="1" />
+            <S N="Name"></S>
+            <S N="StorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=[key hidden]</S>
+            <S N="TableStorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https</S>
+            <Nil N="Track2OauthToken" />
+            <S N="EndPointSuffix">core.windows.net/</S>
+            <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+            <Obj N="ExtendedProperties" RefId="2">
+                <TN RefId="1">
+                <T>System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</T>
+                <T>System.Object</T>
+                </TN>
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <S N="Name"></S>
+        <Obj N="StorageAccount" RefId="3">
+            <TN RefId="2">
+            <T>Microsoft.Azure.Storage.CloudStorageAccount</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=[key hidden]</ToString>
+            <Props>
+            <URI N="BlobEndpoint">https://aadeploymentstor.blob.core.windows.net/</URI>
+            <URI N="QueueEndpoint">https://aadeploymentstor.queue.core.windows.net/</URI>
+            <URI N="TableEndpoint">https://aadeploymentstor.table.core.windows.net/</URI>
+            <URI N="FileEndpoint">https://aadeploymentstor.file.core.windows.net/</URI>
+            <S N="BlobStorageUri">Primary = 'https://aadeploymentstor.blob.core.windows.net/'; Secondary = ''</S>
+            <S N="QueueStorageUri">Primary = 'https://aadeploymentstor.queue.core.windows.net/'; Secondary = ''</S>
+            <S N="TableStorageUri">Primary = 'https://aadeploymentstor.table.core.windows.net/'; Secondary = ''</S>
+            <S N="FileStorageUri">Primary = 'https://aadeploymentstor.file.core.windows.net/'; Secondary = ''</S>
+            <S N="Credentials">Microsoft.Azure.Storage.Auth.StorageCredentials</S>
+            </Props>
+        </Obj>
+        <Obj N="TableStorageAccount" RefId="4">
+            <TN RefId="3">
+            <T>Microsoft.Azure.Cosmos.Table.CloudStorageAccount</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https</ToString>
+            <Props>
+            <URI N="TableEndpoint">https://aadeploymentstor.table.core.windows.net/</URI>
+            <S N="TableStorageUri">Primary = 'https://aadeploymentstor.table.core.windows.net/'; Secondary = ''</S>
+            <S N="Credentials">Microsoft.Azure.Cosmos.Table.StorageCredentials</S>
+            </Props>
+        </Obj>
+        <Nil N="Track2OauthToken" />
+        <S N="EndPointSuffix">core.windows.net/</S>
+        <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+        <Ref N="ExtendedProperties" RefId="2" />
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' New-AzStorageBlobSASToken {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <S>https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip?sv=2019-02-02&amp;sr=b&amp;sig=if5HREXrRThQDVCvfCQI3ukJTvGtsJvQMNB6nkBkX4E%3D&amp;se=2020-05-12T12%3A30%3A57Z&amp;sp=r</S>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' Set-AzStorageBlobContent {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageBlob</T>
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageBase</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageBlob</ToString>
+        <Props>
+        <Obj N="ICloudBlob" RefId="1">
+            <TN RefId="1">
+            <T>Microsoft.Azure.Storage.Blob.CloudBlockBlob</T>
+            <T>Microsoft.Azure.Storage.Blob.CloudBlob</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Storage.Blob.CloudBlockBlob</ToString>
+            <Props>
+            <I32 N="StreamWriteSizeInBytes">4194304</I32>
+            <S N="ServiceClient">Microsoft.Azure.Storage.Blob.CloudBlobClient</S>
+            <I32 N="StreamMinimumReadSizeInBytes">4194304</I32>
+            <S N="Properties">Microsoft.Azure.Storage.Blob.BlobProperties</S>
+            <Obj N="Metadata" RefId="2">
+                <TN RefId="2">
+                <T>System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</T>
+                <T>System.Object</T>
+                </TN>
+                <DCT />
+            </Obj>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip</URI>
+            <S N="StorageUri">Primary = 'https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip'; Secondary = ''</S>
+            <Nil N="SnapshotTime" />
+            <B N="IsSnapshot">false</B>
+            <B N="IsDeleted">false</B>
+            <URI N="SnapshotQualifiedUri">https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip</URI>
+            <S N="SnapshotQualifiedStorageUri">Primary = 'https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip'; Secondary = ''</S>
+            <Nil N="CopyState" />
+            <S N="Name">PSDepend.zip</S>
+            <S N="Container">Microsoft.Azure.Storage.Blob.CloudBlobContainer</S>
+            <S N="Parent">Microsoft.Azure.Storage.Blob.CloudBlobDirectory</S>
+            <S N="BlobType">BlockBlob</S>
+            </Props>
+        </Obj>
+        <Obj N="BlobType" RefId="3">
+            <TN RefId="3">
+            <T>Microsoft.Azure.Storage.Blob.BlobType</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>BlockBlob</ToString>
+            <I32>2</I32>
+        </Obj>
+        <I64 N="Length">2274</I64>
+        <B N="IsDeleted">false</B>
+        <Obj N="BlobClient" RefId="4">
+            <TN RefId="4">
+            <T>Azure.Storage.Blobs.BlobClient</T>
+            <T>Azure.Storage.Blobs.Specialized.BlobBaseClient</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.BlobClient</ToString>
+            <Props>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip</URI>
+            <S N="AccountName">aadeploymentstor</S>
+            <S N="BlobContainerName">psdepend</S>
+            <S N="Name">PSDepend.zip</S>
+            </Props>
+        </Obj>
+        <Obj N="BlobProperties" RefId="5">
+            <TN RefId="5">
+            <T>Azure.Storage.Blobs.Models.BlobProperties</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.Models.BlobProperties</ToString>
+            <Props>
+            <S N="LastModified">05/12/2020 11:22:11 +00:00</S>
+            <S N="CreatedOn">05/04/2020 14:45:45 +00:00</S>
+            <Obj N="Metadata" RefId="6">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            <S N="BlobType">Block</S>
+            <S N="CopyCompletedOn">01/01/0001 00:00:00 +00:00</S>
+            <Nil N="CopyStatusDescription" />
+            <Nil N="CopyId" />
+            <Nil N="CopyProgress" />
+            <Nil N="CopySource" />
+            <S N="CopyStatus">Pending</S>
+            <B N="IsIncrementalCopy">false</B>
+            <Nil N="DestinationSnapshot" />
+            <S N="LeaseDuration">Infinite</S>
+            <S N="LeaseState">Available</S>
+            <S N="LeaseStatus">Unlocked</S>
+            <I64 N="ContentLength">2274</I64>
+            <S N="ContentType">application/octet-stream</S>
+            <S N="ETag">"0x8D7F666B761B3E1"</S>
+            <BA N="ContentHash">Oz7uCTeqWbwPHzSXuNcHFw==</BA>
+            <Nil N="ContentEncoding" />
+            <Nil N="ContentDisposition" />
+            <Nil N="ContentLanguage" />
+            <Nil N="CacheControl" />
+            <I64 N="BlobSequenceNumber">0</I64>
+            <S N="AcceptRanges">bytes</S>
+            <I32 N="BlobCommittedBlockCount">0</I32>
+            <B N="IsServerEncrypted">true</B>
+            <Nil N="EncryptionKeySha256" />
+            <Nil N="EncryptionScope" />
+            <S N="AccessTier">Hot</S>
+            <B N="AccessTierInferred">true</B>
+            <Nil N="ArchiveStatus" />
+            <S N="AccessTierChangedOn">01/01/0001 00:00:00 +00:00</S>
+            </Props>
+        </Obj>
+        <Nil N="RemainingDaysBeforePermanentDelete" />
+        <S N="ContentType">application/octet-stream</S>
+        <Obj N="LastModified" RefId="7">
+            <TN RefId="6">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/12/2020 11:22:11 +00:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-12T11:22:11</DT>
+            <DT N="UtcDateTime">2020-05-12T11:22:11Z</DT>
+            <DT N="LocalDateTime">2020-05-12T14:22:11+03:00</DT>
+            <DT N="Date">2020-05-12T00:00:00</DT>
+            <I32 N="Day">12</I32>
+            <S N="DayOfWeek">Tuesday</S>
+            <I32 N="DayOfYear">133</I32>
+            <I32 N="Hour">11</I32>
+            <I32 N="Millisecond">0</I32>
+            <I32 N="Minute">22</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT0S</TS>
+            <I32 N="Second">11</I32>
+            <I64 N="Ticks">637248793310000000</I64>
+            <I64 N="UtcTicks">637248793310000000</I64>
+            <TS N="TimeOfDay">PT11H22M11S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Nil N="SnapshotTime" />
+        <Nil N="ContinuationToken" />
+        <Obj N="Context" RefId="8">
+            <TN RefId="7">
+            <T>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</ToString>
+            <Props>
+            <S N="StorageAccountName">aadeploymentstor</S>
+            <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+            <Ref N="Context" RefId="8" />
+            <S N="Name"></S>
+            <S N="StorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=[key hidden]</S>
+            <S N="TableStorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https</S>
+            <Nil N="Track2OauthToken" />
+            <S N="EndPointSuffix">core.windows.net/</S>
+            <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+            <Obj N="ExtendedProperties" RefId="9">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <S N="Name">PSDepend.zip</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+
+            It 'should get an Automation account' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force
+                    Assert-MockCalled Get-AzAutomationAccount -Exactly 1 -Scope It
+                }
+            }
+
+            It 'should query the Automation account for already imported module' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force
+                    Assert-MockCalled Get-AzAutomationModule -Exactly 1 -Scope It
+                }
+            }
+
+            It 'should import the module into Automation account' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force
+                    Assert-MockCalled New-AzAutomationModule -Exactly 1 -Scope It
+                }
+            }
+
+            It 'should use a Storage account' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force
+                    Assert-MockCalled Get-AzStorageAccount -Exactly 1 -Scope It
+                    Assert-MockCalled Get-AzStorageContainer -Exactly 1 -Scope It
+                    Assert-MockCalled Get-AzStorageAccountKey -Exactly 1 -Scope It
+                    Assert-MockCalled New-AzStorageContainer -Exactly 0 -Scope It
+                    Assert-MockCalled New-AzStorageContext -Exactly 1 -Scope It
+                    Assert-MockCalled New-AzStorageBlobSASToken -Exactly 1 -Scope It
+                    Assert-MockCalled Set-AzStorageBlobContent -Exactly 1 -Scope It
+                }
+            }
+        }
+
+        Context 'Script Logic - Source Module' {
+
+            Mock -ModuleName 'Az.Automation' Get-AzAutomationAccount {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Automation.Model.AutomationAccount</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Commands.Automation.Model.AutomationAccount</ToString>
+        <Props>
+        <S N="SubscriptionId">c49124fa-befd-4207-a3b7-29c95c41a964</S>
+        <S N="ResourceGroupName">AAResourceGroupName</S>
+        <S N="AutomationAccountName">AAName</S>
+        <S N="Location">westeurope</S>
+        <S N="State">Ok</S>
+        <S N="Plan">Basic</S>
+        <Obj N="CreationTime" RefId="1">
+            <TN RefId="1">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>10/02/2017 16:05:15 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2017-10-02T16:05:15.39</DT>
+            <DT N="UtcDateTime">2017-10-02T13:05:15.39Z</DT>
+            <DT N="LocalDateTime">2017-10-02T16:05:15.39+03:00</DT>
+            <DT N="Date">2017-10-02T00:00:00</DT>
+            <I32 N="Day">2</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">275</I32>
+            <I32 N="Hour">16</I32>
+            <I32 N="Millisecond">390</I32>
+            <I32 N="Minute">5</I32>
+            <I32 N="Month">10</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">15</I32>
+            <I64 N="Ticks">636425571153900000</I64>
+            <I64 N="UtcTicks">636425463153900000</I64>
+            <TS N="TimeOfDay">PT16H5M15.39S</TS>
+            <I32 N="Year">2017</I32>
+            </Props>
+        </Obj>
+        <Obj N="LastModifiedTime" RefId="2">
+            <TNRef RefId="1" />
+            <ToString>03/22/2020 10:41:20 +02:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-03-22T10:41:20.57</DT>
+            <DT N="UtcDateTime">2020-03-22T08:41:20.57Z</DT>
+            <DT N="LocalDateTime">2020-03-22T10:41:20.57+02:00</DT>
+            <DT N="Date">2020-03-22T00:00:00</DT>
+            <I32 N="Day">22</I32>
+            <S N="DayOfWeek">Sunday</S>
+            <I32 N="DayOfYear">82</I32>
+            <I32 N="Hour">10</I32>
+            <I32 N="Millisecond">570</I32>
+            <I32 N="Minute">41</I32>
+            <I32 N="Month">3</I32>
+            <TS N="Offset">PT2H</TS>
+            <I32 N="Second">20</I32>
+            <I64 N="Ticks">637204704805700000</I64>
+            <I64 N="UtcTicks">637204632805700000</I64>
+            <TS N="TimeOfDay">PT10H41M20.57S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Nil N="LastModifiedBy" />
+        <Obj N="Tags" RefId="3">
+            <TN RefId="2">
+            <T>System.Collections.Hashtable</T>
+            <T>System.Object</T>
+            </TN>
+            <DCT>
+            <En>
+                <S N="Key">environment</S>
+                <S N="Value">Test</S>
+            </En>
+            </DCT>
+        </Obj>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Automation' Get-AzAutomationModule {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Automation.Model.Module</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Commands.Automation.Model.Module</ToString>
+        <Props>
+        <S N="ResourceGroupName">AAResourceGroupName</S>
+        <S N="AutomationAccountName">AANAme</S>
+        <S N="Name">PSDepend</S>
+        <B N="IsGlobal">false</B>
+        <S N="Version">0.3.2</S>
+        <I64 N="SizeInBytes">71093</I64>
+        <I32 N="ActivityCount">8</I32>
+        <Obj N="CreationTime" RefId="1">
+            <TN RefId="1">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/04/2020 17:42:32 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T17:42:32.617</DT>
+            <DT N="UtcDateTime">2020-05-04T14:42:32.617Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:42:32.617+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">17</I32>
+            <I32 N="Millisecond">617</I32>
+            <I32 N="Minute">42</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">32</I32>
+            <I64 N="Ticks">637242109526170000</I64>
+            <I64 N="UtcTicks">637242001526170000</I64>
+            <TS N="TimeOfDay">PT17H42M32.617S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Obj N="LastModifiedTime" RefId="2">
+            <TNRef RefId="1" />
+            <ToString>05/04/2020 17:44:14 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T17:44:14.537</DT>
+            <DT N="UtcDateTime">2020-05-04T14:44:14.537Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:44:14.537+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">17</I32>
+            <I32 N="Millisecond">537</I32>
+            <I32 N="Minute">44</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">14</I32>
+            <I64 N="Ticks">637242110545370000</I64>
+            <I64 N="UtcTicks">637242002545370000</I64>
+            <TS N="TimeOfDay">PT17H44M14.537S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <S N="ProvisioningState">Succeeded</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Automation' New-AzAutomationModule {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Automation.Model.Module</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Commands.Automation.Model.Module</ToString>
+        <Props>
+        <S N="ResourceGroupName">AAResourceGroupName</S>
+        <S N="AutomationAccountName">AAName</S>
+        <S N="Name">PSDepend</S>
+        <B N="IsGlobal">false</B>
+        <S N="Version">0.3.2</S>
+        <I64 N="SizeInBytes">71093</I64>
+        <I32 N="ActivityCount">8</I32>
+        <Obj N="CreationTime" RefId="1">
+            <TN RefId="1">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/04/2020 17:42:32 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T17:42:32.617</DT>
+            <DT N="UtcDateTime">2020-05-04T14:42:32.617Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:42:32.617+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">17</I32>
+            <I32 N="Millisecond">617</I32>
+            <I32 N="Minute">42</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">32</I32>
+            <I64 N="Ticks">637242109526170000</I64>
+            <I64 N="UtcTicks">637242001526170000</I64>
+            <TS N="TimeOfDay">PT17H42M32.617S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Obj N="LastModifiedTime" RefId="2">
+            <TNRef RefId="1" />
+            <ToString>05/12/2020 14:05:27 +03:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-12T14:05:27.527</DT>
+            <DT N="UtcDateTime">2020-05-12T11:05:27.527Z</DT>
+            <DT N="LocalDateTime">2020-05-12T14:05:27.527+03:00</DT>
+            <DT N="Date">2020-05-12T00:00:00</DT>
+            <I32 N="Day">12</I32>
+            <S N="DayOfWeek">Tuesday</S>
+            <I32 N="DayOfYear">133</I32>
+            <I32 N="Hour">14</I32>
+            <I32 N="Millisecond">527</I32>
+            <I32 N="Minute">5</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT3H</TS>
+            <I32 N="Second">27</I32>
+            <I64 N="Ticks">637248891275270000</I64>
+            <I64 N="UtcTicks">637248783275270000</I64>
+            <TS N="TimeOfDay">PT14H5M27.527S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <S N="ProvisioningState">Succeeded</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' Get-AzStorageAccount {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Commands.Management.Storage.Models.PSStorageAccount</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString />
+        <Props>
+        <S N="ResourceGroupName">SATestAutomationAndMonitoringRG</S>
+        <S N="StorageAccountName">aadeploymentstor</S>
+        <S N="Id">/subscriptions/eb31e8d0-5a14-4eea-87b9-66581523e545/resourceGroups/SATestAutomationAndMonitoringRG/providers/Microsoft.Storage/storageAccounts/aadeploymentstor</S>
+        <S N="Location">westeurope</S>
+        <Obj N="Sku" RefId="1">
+            <TN RefId="1">
+            <T>Microsoft.Azure.Commands.Management.Storage.Models.PSSku</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Commands.Management.Storage.Models.PSSku</ToString>
+            <Props>
+            <S N="Name">Standard_LRS</S>
+            <S N="Tier">Standard</S>
+            <Nil N="ResourceType" />
+            <Nil N="Kind" />
+            <Nil N="Locations" />
+            <Nil N="Capabilities" />
+            <Nil N="Restrictions" />
+            </Props>
+        </Obj>
+        <S N="Kind">StorageV2</S>
+        <Obj N="Encryption" RefId="2">
+            <TN RefId="2">
+            <T>Microsoft.Azure.Management.Storage.Models.Encryption</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Management.Storage.Models.Encryption</ToString>
+            <Props>
+            <S N="Services">Microsoft.Azure.Management.Storage.Models.EncryptionServices</S>
+            <S N="KeySource">Microsoft.Storage</S>
+            <Nil N="KeyVaultProperties" />
+            </Props>
+        </Obj>
+        <Obj N="AccessTier" RefId="3">
+            <TN RefId="3">
+            <T>Microsoft.Azure.Management.Storage.Models.AccessTier</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Hot</ToString>
+            <I32>0</I32>
+        </Obj>
+        <DT N="CreationTime">2020-05-03T10:59:39.4378401Z</DT>
+        <Nil N="CustomDomain" />
+        <Nil N="Identity" />
+        <Nil N="LastGeoFailoverTime" />
+        <Obj N="PrimaryEndpoints" RefId="4">
+            <TN RefId="4">
+            <T>Microsoft.Azure.Management.Storage.Models.Endpoints</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Management.Storage.Models.Endpoints</ToString>
+            <Props>
+            <S N="Blob">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="Queue">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="Table">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="File">https://aadeploymentstor.file.core.windows.net/</S>
+            <S N="Web">https://aadeploymentstor.z6.web.core.windows.net/</S>
+            <S N="Dfs">https://aadeploymentstor.dfs.core.windows.net/</S>
+            <Nil N="MicrosoftEndpoints" />
+            <Nil N="InternetEndpoints" />
+            </Props>
+        </Obj>
+        <S N="PrimaryLocation">westeurope</S>
+        <Obj N="ProvisioningState" RefId="5">
+            <TN RefId="5">
+            <T>Microsoft.Azure.Management.Storage.Models.ProvisioningState</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Succeeded</ToString>
+            <I32>2</I32>
+        </Obj>
+        <Nil N="SecondaryEndpoints" />
+        <Nil N="SecondaryLocation" />
+        <Obj N="StatusOfPrimary" RefId="6">
+            <TN RefId="6">
+            <T>Microsoft.Azure.Management.Storage.Models.AccountStatus</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Available</ToString>
+            <I32>0</I32>
+        </Obj>
+        <Nil N="StatusOfSecondary" />
+        <Obj N="Tags" RefId="7">
+            <TN RefId="7">
+            <T>System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</T>
+            <T>System.Object</T>
+            </TN>
+            <DCT>
+            <En>
+                <S N="Key">environment</S>
+                <S N="Value">Test</S>
+            </En>
+            </DCT>
+        </Obj>
+        <B N="EnableHttpsTrafficOnly">true</B>
+        <Nil N="AzureFilesIdentityBasedAuth" />
+        <Nil N="EnableHierarchicalNamespace" />
+        <S N="LargeFileSharesState">Disabled</S>
+        <Obj N="NetworkRuleSet" RefId="8">
+            <TN RefId="8">
+            <T>Microsoft.Azure.Commands.Management.Storage.Models.PSNetworkRuleSet</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Commands.Management.Storage.Models.PSNetworkRuleSet</ToString>
+            <Props>
+            <Obj N="IpRules" RefId="9">
+                <TN RefId="9">
+                <T>Microsoft.Azure.Commands.Management.Storage.Models.PSIpRule[]</T>
+                <T>System.Array</T>
+                <T>System.Object</T>
+                </TN>
+                <LST />
+            </Obj>
+            <Obj N="VirtualNetworkRules" RefId="10">
+                <TN RefId="10">
+                <T>Microsoft.Azure.Commands.Management.Storage.Models.PSVirtualNetworkRule[]</T>
+                <T>System.Array</T>
+                <T>System.Object</T>
+                </TN>
+                <LST />
+            </Obj>
+            <S N="Bypass">AzureServices</S>
+            <S N="DefaultAction">Allow</S>
+            </Props>
+        </Obj>
+        <Nil N="GeoReplicationStats" />
+        <Obj N="Context" RefId="11">
+            <TN RefId="11">
+            <T>Microsoft.WindowsAzure.Commands.Common.Storage.LazyAzureStorageContext</T>
+            <T>Microsoft.WindowsAzure.Commands.Common.Storage.AzureStorageContext</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.WindowsAzure.Commands.Common.Storage.LazyAzureStorageContext</ToString>
+            <Props>
+            <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+            <S N="StorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=[key hidden]</S>
+            <S N="StorageAccountName">aadeploymentstor</S>
+            <Ref N="Context" RefId="11" />
+            <S N="Name">aadeploymentstor</S>
+            <S N="EndPointSuffix">core.windows.net/</S>
+            <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+            <Obj N="ExtendedProperties" RefId="12">
+                <TNRef RefId="7" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <Obj N="ExtendedProperties" RefId="13">
+            <TNRef RefId="7" />
+            <DCT />
+        </Obj>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' Get-AzStorageContainer {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageContainer</T>
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageBase</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageContainer</ToString>
+        <Props>
+        <Obj N="CloudBlobContainer" RefId="1">
+            <TN RefId="1">
+            <T>Microsoft.Azure.Storage.Blob.CloudBlobContainer</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Storage.Blob.CloudBlobContainer</ToString>
+            <Props>
+            <S N="ServiceClient">Microsoft.Azure.Storage.Blob.CloudBlobClient</S>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend</URI>
+            <S N="StorageUri">Primary = 'https://aadeploymentstor.blob.core.windows.net/psdepend'; Secondary = ''</S>
+            <S N="Name">psdepend</S>
+            <Obj N="Metadata" RefId="2">
+                <TN RefId="2">
+                <T>System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</T>
+                <T>System.Object</T>
+                </TN>
+                <DCT />
+            </Obj>
+            <S N="Properties">Microsoft.Azure.Storage.Blob.BlobContainerProperties</S>
+            </Props>
+        </Obj>
+        <Obj N="Permission" RefId="3">
+            <TN RefId="3">
+            <T>Microsoft.Azure.Storage.Blob.BlobContainerPermissions</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Storage.Blob.BlobContainerPermissions</ToString>
+            <Props>
+            <S N="PublicAccess">Container</S>
+            <Obj N="SharedAccessPolicies" RefId="4">
+                <TN RefId="4">
+                <T>Microsoft.Azure.Storage.Blob.SharedAccessBlobPolicies</T>
+                <T>System.Object</T>
+                </TN>
+                <IE />
+            </Obj>
+            </Props>
+        </Obj>
+        <Obj N="PublicAccess" RefId="5">
+            <TN RefId="5">
+            <T>Microsoft.Azure.Storage.Blob.BlobContainerPublicAccessType</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Container</ToString>
+            <I32>1</I32>
+        </Obj>
+        <Obj N="LastModified" RefId="6">
+            <TN RefId="6">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/04/2020 14:45:45 +00:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T14:45:45</DT>
+            <DT N="UtcDateTime">2020-05-04T14:45:45Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:45:45+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">14</I32>
+            <I32 N="Millisecond">0</I32>
+            <I32 N="Minute">45</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT0S</TS>
+            <I32 N="Second">45</I32>
+            <I64 N="Ticks">637242003450000000</I64>
+            <I64 N="UtcTicks">637242003450000000</I64>
+            <TS N="TimeOfDay">PT14H45M45S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Nil N="ContinuationToken" />
+        <Obj N="BlobContainerClient" RefId="7">
+            <TN RefId="7">
+            <T>Azure.Storage.Blobs.BlobContainerClient</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.BlobContainerClient</ToString>
+            <Props>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend</URI>
+            <S N="AccountName">aadeploymentstor</S>
+            <S N="Name">psdepend</S>
+            </Props>
+        </Obj>
+        <Obj N="BlobContainerProperties" RefId="8">
+            <TN RefId="8">
+            <T>Azure.Storage.Blobs.Models.BlobContainerProperties</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.Models.BlobContainerProperties</ToString>
+            <Props>
+            <S N="LastModified">05/04/2020 14:45:45 +00:00</S>
+            <S N="LeaseStatus">Unlocked</S>
+            <S N="LeaseState">Available</S>
+            <S N="LeaseDuration">Infinite</S>
+            <S N="PublicAccess">BlobContainer</S>
+            <B N="HasImmutabilityPolicy">false</B>
+            <B N="HasLegalHold">false</B>
+            <S N="DefaultEncryptionScope">$account-encryption-key</S>
+            <B N="PreventEncryptionScopeOverride">false</B>
+            <S N="ETag">"0x8D7F039D3D0C5C5"</S>
+            <Obj N="Metadata" RefId="9">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <Obj N="Context" RefId="10">
+            <TN RefId="9">
+            <T>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</ToString>
+            <Props>
+            <S N="StorageAccountName">aadeploymentstor</S>
+            <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+            <Ref N="Context" RefId="10" />
+            <S N="Name"></S>
+            <S N="StorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https;AccountName=aadeploymentstor;AccountKey=[key hidden]</S>
+            <S N="TableStorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https</S>
+            <Nil N="Track2OauthToken" />
+            <S N="EndPointSuffix">core.windows.net/</S>
+            <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+            <Obj N="ExtendedProperties" RefId="11">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <S N="Name">psdepend</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' Get-AzStorageAccountKey {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.Azure.Management.Storage.Models.StorageAccountKey</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.Azure.Management.Storage.Models.StorageAccountKey</ToString>
+        <Props>
+        <S N="KeyName">key1</S>
+        <S N="Value">aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+        <Obj N="Permissions" RefId="1">
+            <TN RefId="1">
+            <T>Microsoft.Azure.Management.Storage.Models.KeyPermission</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Full</ToString>
+            <I32>1</I32>
+        </Obj>
+        </Props>
+    </Obj>
+    <Obj RefId="2">
+        <TNRef RefId="0" />
+        <ToString>Microsoft.Azure.Management.Storage.Models.StorageAccountKey</ToString>
+        <Props>
+        <S N="KeyName">key2</S>
+        <S N="Value">lCvSampwF8ZkAgjaDJXpw3akynx5aEecS3Wg/WDeygQd7l+/bXMZD+uk0Dd0Jbk2tZ7nBO39W0fGXsZBQtK0zQ==</S>
+        <Obj N="Permissions" RefId="3">
+            <TNRef RefId="1" />
+            <ToString>Full</ToString>
+            <I32>1</I32>
+        </Obj>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' New-AzStorageContainer {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageContainer</T>
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageBase</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageContainer</ToString>
+        <Props>
+        <Obj N="CloudBlobContainer" RefId="1">
+            <TN RefId="1">
+            <T>Microsoft.Azure.Storage.Blob.CloudBlobContainer</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Storage.Blob.CloudBlobContainer</ToString>
+            <Props>
+            <S N="ServiceClient">Microsoft.Azure.Storage.Blob.CloudBlobClient</S>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend</URI>
+            <S N="StorageUri">Primary = 'https://aadeploymentstor.blob.core.windows.net/psdepend'; Secondary = ''</S>
+            <S N="Name">psdepend</S>
+            <Obj N="Metadata" RefId="2">
+                <TN RefId="2">
+                <T>System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</T>
+                <T>System.Object</T>
+                </TN>
+                <DCT />
+            </Obj>
+            <S N="Properties">Microsoft.Azure.Storage.Blob.BlobContainerProperties</S>
+            </Props>
+        </Obj>
+        <Obj N="Permission" RefId="3">
+            <TN RefId="3">
+            <T>Microsoft.Azure.Storage.Blob.BlobContainerPermissions</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Storage.Blob.BlobContainerPermissions</ToString>
+            <Props>
+            <S N="PublicAccess">Container</S>
+            <Obj N="SharedAccessPolicies" RefId="4">
+                <TN RefId="4">
+                <T>Microsoft.Azure.Storage.Blob.SharedAccessBlobPolicies</T>
+                <T>System.Object</T>
+                </TN>
+                <IE />
+            </Obj>
+            </Props>
+        </Obj>
+        <Obj N="PublicAccess" RefId="5">
+            <TN RefId="5">
+            <T>Microsoft.Azure.Storage.Blob.BlobContainerPublicAccessType</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Container</ToString>
+            <I32>1</I32>
+        </Obj>
+        <Obj N="LastModified" RefId="6">
+            <TN RefId="6">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/04/2020 14:45:45 +00:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-04T14:45:45</DT>
+            <DT N="UtcDateTime">2020-05-04T14:45:45Z</DT>
+            <DT N="LocalDateTime">2020-05-04T17:45:45+03:00</DT>
+            <DT N="Date">2020-05-04T00:00:00</DT>
+            <I32 N="Day">4</I32>
+            <S N="DayOfWeek">Monday</S>
+            <I32 N="DayOfYear">125</I32>
+            <I32 N="Hour">14</I32>
+            <I32 N="Millisecond">0</I32>
+            <I32 N="Minute">45</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT0S</TS>
+            <I32 N="Second">45</I32>
+            <I64 N="Ticks">637242003450000000</I64>
+            <I64 N="UtcTicks">637242003450000000</I64>
+            <TS N="TimeOfDay">PT14H45M45S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Nil N="ContinuationToken" />
+        <Obj N="BlobContainerClient" RefId="7">
+            <TN RefId="7">
+            <T>Azure.Storage.Blobs.BlobContainerClient</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.BlobContainerClient</ToString>
+            <Props>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend</URI>
+            <S N="AccountName">aadeploymentstor</S>
+            <S N="Name">psdepend</S>
+            </Props>
+        </Obj>
+        <Obj N="BlobContainerProperties" RefId="8">
+            <TN RefId="8">
+            <T>Azure.Storage.Blobs.Models.BlobContainerProperties</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.Models.BlobContainerProperties</ToString>
+            <Props>
+            <S N="LastModified">05/04/2020 14:45:45 +00:00</S>
+            <S N="LeaseStatus">Unlocked</S>
+            <S N="LeaseState">Available</S>
+            <S N="LeaseDuration">Infinite</S>
+            <S N="PublicAccess">BlobContainer</S>
+            <B N="HasImmutabilityPolicy">false</B>
+            <B N="HasLegalHold">false</B>
+            <S N="DefaultEncryptionScope">$account-encryption-key</S>
+            <B N="PreventEncryptionScopeOverride">false</B>
+            <S N="ETag">"0x8D7F039D3D0C5C5"</S>
+            <Obj N="Metadata" RefId="9">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <Obj N="Context" RefId="10">
+            <TN RefId="9">
+            <T>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</ToString>
+            <Props>
+            <S N="StorageAccountName">aadeploymentstor</S>
+            <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+            <Ref N="Context" RefId="10" />
+            <S N="Name"></S>
+            <S N="StorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https;AccountName=aadeploymentstor;AccountKey=[key hidden]</S>
+            <S N="TableStorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https</S>
+            <Nil N="Track2OauthToken" />
+            <S N="EndPointSuffix">core.windows.net/</S>
+            <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+            <Obj N="ExtendedProperties" RefId="11">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <S N="Name">psdepend</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' New-AzStorageContext {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</ToString>
+        <Props>
+        <S N="StorageAccountName">aadeploymentstor</S>
+        <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+        <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+        <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+        <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+        <Obj N="Context" RefId="1">
+            <TNRef RefId="0" />
+            <ToString>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</ToString>
+            <Props>
+            <S N="StorageAccountName">aadeploymentstor</S>
+            <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+            <Ref N="Context" RefId="1" />
+            <S N="Name"></S>
+            <S N="StorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=[key hidden]</S>
+            <S N="TableStorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https</S>
+            <Nil N="Track2OauthToken" />
+            <S N="EndPointSuffix">core.windows.net/</S>
+            <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+            <Obj N="ExtendedProperties" RefId="2">
+                <TN RefId="1">
+                <T>System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</T>
+                <T>System.Object</T>
+                </TN>
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <S N="Name"></S>
+        <Obj N="StorageAccount" RefId="3">
+            <TN RefId="2">
+            <T>Microsoft.Azure.Storage.CloudStorageAccount</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=[key hidden]</ToString>
+            <Props>
+            <URI N="BlobEndpoint">https://aadeploymentstor.blob.core.windows.net/</URI>
+            <URI N="QueueEndpoint">https://aadeploymentstor.queue.core.windows.net/</URI>
+            <URI N="TableEndpoint">https://aadeploymentstor.table.core.windows.net/</URI>
+            <URI N="FileEndpoint">https://aadeploymentstor.file.core.windows.net/</URI>
+            <S N="BlobStorageUri">Primary = 'https://aadeploymentstor.blob.core.windows.net/'; Secondary = ''</S>
+            <S N="QueueStorageUri">Primary = 'https://aadeploymentstor.queue.core.windows.net/'; Secondary = ''</S>
+            <S N="TableStorageUri">Primary = 'https://aadeploymentstor.table.core.windows.net/'; Secondary = ''</S>
+            <S N="FileStorageUri">Primary = 'https://aadeploymentstor.file.core.windows.net/'; Secondary = ''</S>
+            <S N="Credentials">Microsoft.Azure.Storage.Auth.StorageCredentials</S>
+            </Props>
+        </Obj>
+        <Obj N="TableStorageAccount" RefId="4">
+            <TN RefId="3">
+            <T>Microsoft.Azure.Cosmos.Table.CloudStorageAccount</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https</ToString>
+            <Props>
+            <URI N="TableEndpoint">https://aadeploymentstor.table.core.windows.net/</URI>
+            <S N="TableStorageUri">Primary = 'https://aadeploymentstor.table.core.windows.net/'; Secondary = ''</S>
+            <S N="Credentials">Microsoft.Azure.Cosmos.Table.StorageCredentials</S>
+            </Props>
+        </Obj>
+        <Nil N="Track2OauthToken" />
+        <S N="EndPointSuffix">core.windows.net/</S>
+        <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+        <Ref N="ExtendedProperties" RefId="2" />
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' New-AzStorageBlobSASToken {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <S>https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip?sv=2019-02-02&amp;sr=b&amp;sig=if5HREXrRThQDVCvfCQI3ukJTvGtsJvQMNB6nkBkX4E%3D&amp;se=2020-05-12T12%3A30%3A57Z&amp;sp=r</S>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+            Mock -ModuleName 'Az.Storage' Set-AzStorageBlobContent {
+                #region MockData
+                $mockedSerializedData = @'
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+    <Obj RefId="0">
+        <TN RefId="0">
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageBlob</T>
+        <T>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageBase</T>
+        <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageBlob</ToString>
+        <Props>
+        <Obj N="ICloudBlob" RefId="1">
+            <TN RefId="1">
+            <T>Microsoft.Azure.Storage.Blob.CloudBlockBlob</T>
+            <T>Microsoft.Azure.Storage.Blob.CloudBlob</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.Azure.Storage.Blob.CloudBlockBlob</ToString>
+            <Props>
+            <I32 N="StreamWriteSizeInBytes">4194304</I32>
+            <S N="ServiceClient">Microsoft.Azure.Storage.Blob.CloudBlobClient</S>
+            <I32 N="StreamMinimumReadSizeInBytes">4194304</I32>
+            <S N="Properties">Microsoft.Azure.Storage.Blob.BlobProperties</S>
+            <Obj N="Metadata" RefId="2">
+                <TN RefId="2">
+                <T>System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</T>
+                <T>System.Object</T>
+                </TN>
+                <DCT />
+            </Obj>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip</URI>
+            <S N="StorageUri">Primary = 'https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip'; Secondary = ''</S>
+            <Nil N="SnapshotTime" />
+            <B N="IsSnapshot">false</B>
+            <B N="IsDeleted">false</B>
+            <URI N="SnapshotQualifiedUri">https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip</URI>
+            <S N="SnapshotQualifiedStorageUri">Primary = 'https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip'; Secondary = ''</S>
+            <Nil N="CopyState" />
+            <S N="Name">PSDepend.zip</S>
+            <S N="Container">Microsoft.Azure.Storage.Blob.CloudBlobContainer</S>
+            <S N="Parent">Microsoft.Azure.Storage.Blob.CloudBlobDirectory</S>
+            <S N="BlobType">BlockBlob</S>
+            </Props>
+        </Obj>
+        <Obj N="BlobType" RefId="3">
+            <TN RefId="3">
+            <T>Microsoft.Azure.Storage.Blob.BlobType</T>
+            <T>System.Enum</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>BlockBlob</ToString>
+            <I32>2</I32>
+        </Obj>
+        <I64 N="Length">2274</I64>
+        <B N="IsDeleted">false</B>
+        <Obj N="BlobClient" RefId="4">
+            <TN RefId="4">
+            <T>Azure.Storage.Blobs.BlobClient</T>
+            <T>Azure.Storage.Blobs.Specialized.BlobBaseClient</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.BlobClient</ToString>
+            <Props>
+            <URI N="Uri">https://aadeploymentstor.blob.core.windows.net/psdepend/PSDepend.zip</URI>
+            <S N="AccountName">aadeploymentstor</S>
+            <S N="BlobContainerName">psdepend</S>
+            <S N="Name">PSDepend.zip</S>
+            </Props>
+        </Obj>
+        <Obj N="BlobProperties" RefId="5">
+            <TN RefId="5">
+            <T>Azure.Storage.Blobs.Models.BlobProperties</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Azure.Storage.Blobs.Models.BlobProperties</ToString>
+            <Props>
+            <S N="LastModified">05/12/2020 11:22:11 +00:00</S>
+            <S N="CreatedOn">05/04/2020 14:45:45 +00:00</S>
+            <Obj N="Metadata" RefId="6">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            <S N="BlobType">Block</S>
+            <S N="CopyCompletedOn">01/01/0001 00:00:00 +00:00</S>
+            <Nil N="CopyStatusDescription" />
+            <Nil N="CopyId" />
+            <Nil N="CopyProgress" />
+            <Nil N="CopySource" />
+            <S N="CopyStatus">Pending</S>
+            <B N="IsIncrementalCopy">false</B>
+            <Nil N="DestinationSnapshot" />
+            <S N="LeaseDuration">Infinite</S>
+            <S N="LeaseState">Available</S>
+            <S N="LeaseStatus">Unlocked</S>
+            <I64 N="ContentLength">2274</I64>
+            <S N="ContentType">application/octet-stream</S>
+            <S N="ETag">"0x8D7F666B761B3E1"</S>
+            <BA N="ContentHash">Oz7uCTeqWbwPHzSXuNcHFw==</BA>
+            <Nil N="ContentEncoding" />
+            <Nil N="ContentDisposition" />
+            <Nil N="ContentLanguage" />
+            <Nil N="CacheControl" />
+            <I64 N="BlobSequenceNumber">0</I64>
+            <S N="AcceptRanges">bytes</S>
+            <I32 N="BlobCommittedBlockCount">0</I32>
+            <B N="IsServerEncrypted">true</B>
+            <Nil N="EncryptionKeySha256" />
+            <Nil N="EncryptionScope" />
+            <S N="AccessTier">Hot</S>
+            <B N="AccessTierInferred">true</B>
+            <Nil N="ArchiveStatus" />
+            <S N="AccessTierChangedOn">01/01/0001 00:00:00 +00:00</S>
+            </Props>
+        </Obj>
+        <Nil N="RemainingDaysBeforePermanentDelete" />
+        <S N="ContentType">application/octet-stream</S>
+        <Obj N="LastModified" RefId="7">
+            <TN RefId="6">
+            <T>System.DateTimeOffset</T>
+            <T>System.ValueType</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>05/12/2020 11:22:11 +00:00</ToString>
+            <Props>
+            <DT N="DateTime">2020-05-12T11:22:11</DT>
+            <DT N="UtcDateTime">2020-05-12T11:22:11Z</DT>
+            <DT N="LocalDateTime">2020-05-12T14:22:11+03:00</DT>
+            <DT N="Date">2020-05-12T00:00:00</DT>
+            <I32 N="Day">12</I32>
+            <S N="DayOfWeek">Tuesday</S>
+            <I32 N="DayOfYear">133</I32>
+            <I32 N="Hour">11</I32>
+            <I32 N="Millisecond">0</I32>
+            <I32 N="Minute">22</I32>
+            <I32 N="Month">5</I32>
+            <TS N="Offset">PT0S</TS>
+            <I32 N="Second">11</I32>
+            <I64 N="Ticks">637248793310000000</I64>
+            <I64 N="UtcTicks">637248793310000000</I64>
+            <TS N="TimeOfDay">PT11H22M11S</TS>
+            <I32 N="Year">2020</I32>
+            </Props>
+        </Obj>
+        <Nil N="SnapshotTime" />
+        <Nil N="ContinuationToken" />
+        <Obj N="Context" RefId="8">
+            <TN RefId="7">
+            <T>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</T>
+            <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext</ToString>
+            <Props>
+            <S N="StorageAccountName">aadeploymentstor</S>
+            <S N="BlobEndPoint">https://aadeploymentstor.blob.core.windows.net/</S>
+            <S N="TableEndPoint">https://aadeploymentstor.table.core.windows.net/</S>
+            <S N="QueueEndPoint">https://aadeploymentstor.queue.core.windows.net/</S>
+            <S N="FileEndPoint">https://aadeploymentstor.file.core.windows.net/</S>
+            <Ref N="Context" RefId="8" />
+            <S N="Name"></S>
+            <S N="StorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=[key hidden]</S>
+            <S N="TableStorageAccount">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;DefaultEndpointsProtocol=https</S>
+            <Nil N="Track2OauthToken" />
+            <S N="EndPointSuffix">core.windows.net/</S>
+            <S N="ConnectionString">BlobEndpoint=https://aadeploymentstor.blob.core.windows.net/;QueueEndpoint=https://aadeploymentstor.queue.core.windows.net/;TableEndpoint=https://aadeploymentstor.table.core.windows.net/;FileEndpoint=https://aadeploymentstor.file.core.windows.net/;AccountName=aadeploymentstor;AccountKey=aYnf1etfwPfXJ2viMYc/DdUcZPo2ysm/42Ov8zEewRGvv32c0VtumseRzoRDG75a7BgCNFiDR28y//xqqBB+Rw==</S>
+            <Obj N="ExtendedProperties" RefId="9">
+                <TNRef RefId="2" />
+                <DCT />
+            </Obj>
+            </Props>
+        </Obj>
+        <S N="Name">PSDepend.zip</S>
+        </Props>
+    </Obj>
+</Objs>
+'@
+                #endregion
+
+                $data = [System.Management.Automation.PSSerializer]::DeserializeAsList($mockedSerializedData)
+                $data
+            }
+
+            It 'should get an Automation account' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force
+                    Assert-MockCalled Get-AzAutomationAccount -Exactly 1 -Scope It
+                }
+            }
+
+            It 'should query the Automation account for already imported module' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force
+                    Assert-MockCalled Get-AzAutomationModule -Exactly 1 -Scope It
+                }
+            }
+
+            It 'should import the module into Automation account' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force
+                    Assert-MockCalled New-AzAutomationModule -Exactly 1 -Scope It
+                }
+            }
+
+            It 'should use a Storage account' {
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1" -Force
+                    Assert-MockCalled Get-AzStorageAccount -Exactly 1 -Scope It
+                    Assert-MockCalled Get-AzStorageContainer -Exactly 1 -Scope It
+                    Assert-MockCalled Get-AzStorageAccountKey -Exactly 1 -Scope It
+                    Assert-MockCalled New-AzStorageContainer -Exactly 0 -Scope It
+                    Assert-MockCalled New-AzStorageContext -Exactly 1 -Scope It
+                    Assert-MockCalled New-AzStorageBlobSASToken -Exactly 1 -Scope It
+                    Assert-MockCalled Set-AzStorageBlobContent -Exactly 1 -Scope It
+                }
+            }
+        }
+    }
+}

--- a/Tests/Types/AzureAutomationRunbook.Tests.ps1
+++ b/Tests/Types/AzureAutomationRunbook.Tests.ps1
@@ -1,0 +1,90 @@
+if(-not $ENV:BHProjectPath)
+{
+    Set-BuildEnvironment -Path $PSScriptRoot\..\.. -Force
+}
+Remove-Module PSDeploy -ErrorAction SilentlyContinue
+Import-Module $PSScriptRoot\..\..\PSDeploy\PSDeploy.psd1
+
+InModuleScope 'PSDeploy' {
+    $PSVersion = $PSVersionTable.PSVersion.Major
+    $ProjectRoot = $ENV:BHProjectPath
+
+    # Define path to the deployment script itself
+    $sutPath = "$ProjectRoot\PSDeploy\PSDeployScripts\AzureAutomationRunbook.ps1"
+
+    $Verbose = @{}
+    if($ENV:BHBranchName -notlike "master" -or $env:BHCommitMessage -match "!verbose")
+    {
+        $Verbose.add("Verbose",$True)
+    }
+
+    Describe "AzureAutomationRunbookScript PS$PSVersion" {
+
+        Context "Code Style" {
+            It "should define CmdletBinding" {
+              $sutPath | Should -FileContentMatch 'CmdletBinding'
+            }
+
+            It "should define parameters" {
+                $sutPath | Should -FileContentMatch 'Param'
+              }
+
+            It "should contain Write-Verbose blocks" {
+              $sutPath | Should -FileContentMatch 'Write-Verbose'
+            }
+
+            It "should be a valid PowerShell code" {
+              $psFile = Get-Content -Path $sutPath -ErrorAction Stop
+              $errors = $null
+              $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
+              $errors.Count | Should -Be 0
+            }
+        }
+
+        Context "Help Quality" {
+
+            # Getting function help
+            $AbstractSyntaxTree = [System.Management.Automation.Language.Parser]::
+            ParseInput((Get-Content -raw $sutPath), [ref]$null, [ref]$null)
+            $AstSearchDelegate = { $args[0] -is [System.Management.Automation.Language.ScriptBlockAst] }
+            $parsedScript = $AbstractSyntaxTree.FindAll( $AstSearchDelegate, $true ) # | Where-Object Name -eq $functionName
+            $scriptHelp = $parsedScript.GetHelpContent()
+
+            It "should have a SYNOPSIS" {
+                $scriptHelp.Synopsis | Should -Not -BeNullOrEmpty
+            }
+
+            It "should have a DESCRIPTION" {
+                $scriptHelp.Description.Length | Should -Not -BeNullOrEmpty
+            }
+
+            It "should have at least one EXAMPLE" {
+                $scriptHelp.Examples.Count | Should -BeGreaterThan 0
+            }
+
+            # Getting the list of function parameters
+            $parameters = $parsedScript.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
+
+            foreach ($parameter in $parameters) {
+                It "should have descriptive help for '$parameter' parameter" {
+                $scriptHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty
+                # $scriptHelp.Parameters.($parameter.ToUpper()).Length | Should -BeGreaterThan 15
+                }
+            }
+        }
+
+        Context 'Script Logic' {
+            Mock Import-AzAutomationRunbook {}
+
+            It 'should publish the runbook' {
+                Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationRunbook.psdeploy.ps1" -Force
+                Assert-MockCalled Import-AzAutomationRunbook -Times 1 -Exactly
+            }
+
+            It "should output into the pipeline" {
+                $result =  { Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationRunbook.psdeploy.ps1" -Force }
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}

--- a/Tests/Types/AzureAutomationRunbook.Tests.ps1
+++ b/Tests/Types/AzureAutomationRunbook.Tests.ps1
@@ -20,22 +20,22 @@ InModuleScope 'PSDeploy' {
 
         Context "Code Style" {
             It "should define CmdletBinding" {
-                $sutPath | Should -FileContentMatch 'CmdletBinding'
+                $sutPath | Should Contain 'CmdletBinding'
             }
 
             It "should define parameters" {
-                $sutPath | Should -FileContentMatch 'Param'
+                $sutPath | Should Contain 'Param'
             }
 
             It "should contain Write-Verbose blocks" {
-                $sutPath | Should -FileContentMatch 'Write-Verbose'
+                $sutPath | Should Contain 'Write-Verbose'
             }
 
             It "should be a valid PowerShell code" {
                 $psFile = Get-Content -Path $sutPath -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
-                $errors.Count | Should -Be 0
+                $errors.Count | Should Be 0
             }
         }
 
@@ -49,15 +49,15 @@ InModuleScope 'PSDeploy' {
             $scriptHelp = $parsedScript.GetHelpContent()
 
             It "should have a SYNOPSIS" {
-                $scriptHelp.Synopsis | Should -Not -BeNullOrEmpty
+                $scriptHelp.Synopsis | Should Not BeNullOrEmpty
             }
 
             It "should have a DESCRIPTION" {
-                $scriptHelp.Description.Length | Should -Not -BeNullOrEmpty
+                $scriptHelp.Description.Length | Should Not BeNullOrEmpty
             }
 
             It "should have at least one EXAMPLE" {
-                $scriptHelp.Examples.Count | Should -BeGreaterThan 0
+                $scriptHelp.Examples.Count | Should BeGreaterThan 0
             }
 
             # Getting the list of function parameters
@@ -65,7 +65,7 @@ InModuleScope 'PSDeploy' {
 
             foreach ($parameter in $parameters) {
                 It "should have descriptive help for '$parameter' parameter" {
-                    $scriptHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty
+                    $scriptHelp.Parameters.($parameter.ToUpper()) | Should Not BeNullOrEmpty
                 }
             }
         }
@@ -82,7 +82,7 @@ InModuleScope 'PSDeploy' {
 
             It "should output into the pipeline" {
                 $result = { Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationRunbook.psdeploy.ps1" -Force }
-                $result | Should -Not -BeNullOrEmpty
+                $result | Should Not BeNullOrEmpty
             }
         }
     }

--- a/Tests/Types/AzureAutomationRunbook.Tests.ps1
+++ b/Tests/Types/AzureAutomationRunbook.Tests.ps1
@@ -76,7 +76,7 @@ InModuleScope 'PSDeploy' {
             It 'should publish the runbook' {
                 {
                     Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationRunbook.psdeploy.ps1" -Force
-                    Assert-MockCalled Import-AzAutomationRunbook -Times 1 -Exactly
+                    Assert-MockCalled Import-AzAutomationRunbook -Exactly 1 -Scope It
                 }
             }
 

--- a/Tests/Types/AzureAutomationRunbook.Tests.ps1
+++ b/Tests/Types/AzureAutomationRunbook.Tests.ps1
@@ -61,13 +61,13 @@ InModuleScope 'PSDeploy' {
             }
 
             # Getting the list of function parameters
-            $parameters = $parsedScript.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
+            <# $parameters = $parsedScript.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
 
             foreach ($parameter in $parameters) {
                 It "should have descriptive help for '$parameter' parameter" {
                     $scriptHelp.Parameters.($parameter.ToUpper()) | Should Not BeNullOrEmpty
                 }
-            }
+            } #>
         }
 
         Context 'Script Logic' {

--- a/Tests/Types/AzureAutomationRunbook.Tests.ps1
+++ b/Tests/Types/AzureAutomationRunbook.Tests.ps1
@@ -1,5 +1,4 @@
-if(-not $ENV:BHProjectPath)
-{
+if (-not $ENV:BHProjectPath) {
     Set-BuildEnvironment -Path $PSScriptRoot\..\.. -Force
 }
 Remove-Module PSDeploy -ErrorAction SilentlyContinue
@@ -13,31 +12,30 @@ InModuleScope 'PSDeploy' {
     $sutPath = "$ProjectRoot\PSDeploy\PSDeployScripts\AzureAutomationRunbook.ps1"
 
     $Verbose = @{}
-    if($ENV:BHBranchName -notlike "master" -or $env:BHCommitMessage -match "!verbose")
-    {
-        $Verbose.add("Verbose",$True)
+    if ($ENV:BHBranchName -notlike "master" -or $env:BHCommitMessage -match "!verbose") {
+        $Verbose.add("Verbose", $True)
     }
 
     Describe "AzureAutomationRunbookScript PS$PSVersion" {
 
         Context "Code Style" {
             It "should define CmdletBinding" {
-              $sutPath | Should -FileContentMatch 'CmdletBinding'
+                $sutPath | Should -FileContentMatch 'CmdletBinding'
             }
 
             It "should define parameters" {
                 $sutPath | Should -FileContentMatch 'Param'
-              }
+            }
 
             It "should contain Write-Verbose blocks" {
-              $sutPath | Should -FileContentMatch 'Write-Verbose'
+                $sutPath | Should -FileContentMatch 'Write-Verbose'
             }
 
             It "should be a valid PowerShell code" {
-              $psFile = Get-Content -Path $sutPath -ErrorAction Stop
-              $errors = $null
-              $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
-              $errors.Count | Should -Be 0
+                $psFile = Get-Content -Path $sutPath -ErrorAction Stop
+                $errors = $null
+                $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
+                $errors.Count | Should -Be 0
             }
         }
 
@@ -67,8 +65,7 @@ InModuleScope 'PSDeploy' {
 
             foreach ($parameter in $parameters) {
                 It "should have descriptive help for '$parameter' parameter" {
-                $scriptHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty
-                # $scriptHelp.Parameters.($parameter.ToUpper()).Length | Should -BeGreaterThan 15
+                    $scriptHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty
                 }
             }
         }
@@ -77,12 +74,14 @@ InModuleScope 'PSDeploy' {
             Mock Import-AzAutomationRunbook {}
 
             It 'should publish the runbook' {
-                Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationRunbook.psdeploy.ps1" -Force
-                Assert-MockCalled Import-AzAutomationRunbook -Times 1 -Exactly
+                {
+                    Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationRunbook.psdeploy.ps1" -Force
+                    Assert-MockCalled Import-AzAutomationRunbook -Times 1 -Exactly
+                }
             }
 
             It "should output into the pipeline" {
-                $result =  { Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationRunbook.psdeploy.ps1" -Force }
+                $result = { Invoke-PSDeploy @Verbose -Path "$ProjectRoot\Tests\artifacts\DeploymentsAzureAutomationRunbook.psdeploy.ps1" -Force }
                 $result | Should -Not -BeNullOrEmpty
             }
         }

--- a/Tests/artifacts/DeploymentsARM.psdeploy.ps1
+++ b/Tests/artifacts/DeploymentsARM.psdeploy.ps1
@@ -9,8 +9,8 @@
 $SubscriptionID = 'INSERT_GUID'
 $ResourceGroupName = 'testrg1'
 $ResourceGroupLocation = 'central us'
-$s = Get-AzureRMSubscription -SubscriptionID $SubscriptionID -ErrorAction SilentlyContinue
-if (!$s) {Login-AzureRMAccount}
+$s = Get-AzSubscription -SubscriptionID $SubscriptionID -ErrorAction SilentlyContinue
+if (!$s) {Login-AzAccount}
 #>
 
 # Map variables from Build system (store encrypted).  This might not be required, depending on the build service, thought it is nice for keeping track of needed variables.
@@ -18,7 +18,7 @@ if (!$s) {Login-AzureRMAccount}
 [string]$tenant = [string]$tenant
 [string]$ID = [string]$ID
 [string]$key = [string]$key
-[string]$subscriptionid = [string]$subscriptionid
+[string]$subscriptionId = [string]$subscriptionId
 [string]$ResourceGroupName = [string]$ResourceGroupName
 [string]$ResourceGroupLocation = [string]$ResourceGroupLocation
 [string]$administratorLogin = [string]$administratorLogin
@@ -27,16 +27,16 @@ if (!$s) {Login-AzureRMAccount}
 # SPN based authentication to Azure
 $key = $key | ConvertTo-SecureString -AsPlainText -Force
 $Credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $ID, $key
-Add-AzureRMAccount -ServicePrincipal -Tenant $Tenant -Credential $Credential
-Select-AzureRMSubscription -SubscriptionId $SubscriptionID
+Add-AzAccount -ServicePrincipal -Tenant $Tenant -Credential $Credential
+Select-AzSubscription -SubscriptionId $SubscriptionID
 
 # Convert string values from Build in to securestring values for Azure cmdlets
 $registrationKey = $registrationKey | ConvertTo-SecureString -AsPlainText -Force
 $administratorLoginPassword = $administratorLoginPassword | ConvertTo-SecureString -AsPlainText -Force
 
 # Verify Resource Group
-$rg = Get-AzureRmResourceGroup -name $ResourceGroupName -ErrorAction SilentlyContinue
-if (!$rg) {$rg = New-AzureRmResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation}
+$rg = Get-AzResourceGroup -name $ResourceGroupName -ErrorAction SilentlyContinue
+if (!$rg) {$rg = New-AzResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation}
 
 # PSDeploy
 Deploy TemplateExample {

--- a/Tests/artifacts/DeploymentsAzureAutomationDscConfiguration.psdeploy.ps1
+++ b/Tests/artifacts/DeploymentsAzureAutomationDscConfiguration.psdeploy.ps1
@@ -1,0 +1,21 @@
+# Deploy a DSC configuration
+Deploy hybridWorkerConfiguration {
+    By AzureAutomationDscConfiguration {
+        FromSource "\Scripts\MMAConfiguration.ps1"
+        To "AAName"
+        WithOptions @{
+            ResourceGroupName = "AAResourceGroup"
+            Published         = $true
+            Force             = $true
+            Compile           = $true
+            ConfigurationData = @{
+                # Node specific data
+                AllNodes = @(
+                    @{
+                         NodeName = "localhost";
+                     }
+                 );
+            }
+        }
+    }
+}

--- a/Tests/artifacts/DeploymentsAzureAutomationModule-PrivateModule.psdeploy.ps1
+++ b/Tests/artifacts/DeploymentsAzureAutomationModule-PrivateModule.psdeploy.ps1
@@ -1,0 +1,21 @@
+# Deploy a module from a private repository
+Deploy PrivateModule {
+    By AzureAutomationModule {
+        FromSource "https://pkgs.dev.azure.com/ORGANIZATION_NAME/PROJECT_NAME/_packaging/FEED_NAME/nuget/v2"
+        To "AAName"
+        WithOptions @{
+            SourceIsAbsolute   = $true
+            ModuleName         = "PrivateModule"
+            # ModuleVersion     = '0.0.4'
+            Force              = $true
+            ResourceGroupName  = "AAResourceGroupName"
+            StorageAccountName = "aadeploymentstor"
+            Credential         = $script:credential
+        }
+        WithPreScript {
+            $user = 'user@contoso.com'
+            $password = ConvertTo-SecureString 'PAT_TOKEN' -AsPlainText -Force # PAT with permissions to read from the Artifacts feed
+            $script:credential = New-Object -TypeName 'System.Management.Automation.PSCredential' -ArgumentList $user, $password
+        }
+    }
+}

--- a/Tests/artifacts/DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1
+++ b/Tests/artifacts/DeploymentsAzureAutomationModule-PublicModule.psdeploy.ps1
@@ -1,0 +1,14 @@
+# Deploy a module from a public repository
+Deploy PSDependModule {
+    By AzureAutomationModule {
+        FromSource "https://www.powershellgallery.com/api/v2"
+        To "AAName"
+        WithOptions @{
+            SourceIsAbsolute  = $true
+            ModuleName        = "PSDepend"
+            # ModuleVersion     = '0.3.0'
+            ResourceGroupName = "AAResourceGroupName"
+            # Force             = $true
+        }
+    }
+}

--- a/Tests/artifacts/DeploymentsAzureAutomationModule-SourceModule.psdeploy.ps1
+++ b/Tests/artifacts/DeploymentsAzureAutomationModule-SourceModule.psdeploy.ps1
@@ -1,0 +1,14 @@
+# Deploy a module from a local path
+Deploy PSDependModule {
+    By AzureAutomationModule {
+        FromSource ".\PSDepend"
+        To "AAName"
+        WithOptions @{
+            ModuleName         = "PSDepend"
+            # ModuleVersion      = '0.3.0'
+            ResourceGroupName  = "AAResourceGroupName"
+            StorageAccountName = "aadeploymentstor"
+            # Force              = $true
+        }
+    }
+}

--- a/Tests/artifacts/DeploymentsAzureAutomationRunbook.psdeploy.ps1
+++ b/Tests/artifacts/DeploymentsAzureAutomationRunbook.psdeploy.ps1
@@ -1,0 +1,12 @@
+# Deploy an Azure Automation runbook
+Deploy New-Runbook {
+    By AzureAutomationRunbook {
+        FromSource "\Scripts\Get-RandomGuid.ps1"
+        To "AAName"
+        WithOptions @{
+            RunbookName       = "Get-RandomGuid"
+            ResourceGroupName = "AAResourceGroup"
+            Force             = $true
+        }
+    }
+}

--- a/Tests/artifacts/Scripts/Get-RandomGuid.ps1
+++ b/Tests/artifacts/Scripts/Get-RandomGuid.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+    Generates a list of random GUIDs
+.DESCRIPTION
+    The Get-RandomGuid cmdlet generates a list of random GUIDs based on the input number
+.PARAMETER Number
+    Number of GUIDs to generate.
+.EXAMPLE
+    Get-RandomGuid -Number 10
+    Accept input data from the parameter
+.EXAMPLE
+    10 | Get-RandomGuid
+    Accept input data from the pipeline
+.INPUTS
+    System.Int
+.OUTPUTS
+    System.Guid
+#>
+
+    [CmdletBinding(
+        PositionalBinding = $true)]
+    [OutputType([System.Guid])]
+    Param (
+        [Parameter(
+            Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [Int]
+        $Number
+    )
+
+begin {
+    Write-Verbose "Runbook started at time: $(Get-Date -Format R)"
+}
+
+process {
+    1..$Number | ForEach-Object { New-Guid }
+}
+
+end {
+    Write-Verbose "Runbook ended at time: $(Get-Date -Format R)"
+}

--- a/Tests/artifacts/Scripts/MMAConfiguration.ps1
+++ b/Tests/artifacts/Scripts/MMAConfiguration.ps1
@@ -1,0 +1,90 @@
+Configuration MMAConfiguration {
+
+    #Importing required DSC resources
+    Import-DscResource -ModuleName PSDesiredStateConfiguration
+    Import-DscResource -ModuleName xPSDesiredStateConfiguration
+
+    #Getting the configuration parameters for deployment
+    $logAnalyticsWorkplaceID = Get-AutomationVariable -Name "logAnalyticsWorkplaceID"
+    $logAnalyticsWorkplaceKey = Get-AutomationVariable -Name "logAnalyticsWorkplaceKey"
+
+    #Download location for Microsoft Monitoring Agent package
+    $logAnalyticsAgentPackageLocalPath = "C:\Deploy\MMASetup-AMD64.exe"
+
+    #Download location for Microsoft Dependency Agent package
+    $dependencyAgentPackageLocalPath = "C:\Deploy\InstallDependencyAgent-Windows.exe"
+
+    Node $AllNodes.NodeName {
+
+        #region Microsoft Monitoring Agent
+
+        #Download installation file for Microsoft Monitoring Agent
+        xRemoteFile logAnalyticsAgentPackage {
+            Uri             = "https://go.microsoft.com/fwlink/?LinkId=828603" # Permalink to the 64-bit version of the agent package
+            DestinationPath = $logAnalyticsAgentPackageLocalPath
+        }
+
+        #Installing Microsoft Monitoring Agent on a host
+        xPackage logAnalyticsAgent {
+            Name      = "Microsoft Monitoring Agent"
+            Ensure    = "Present"
+            Path      = $logAnalyticsAgentPackageLocalPath
+            Arguments = '/C:"setup.exe /qn ADD_OPINSIGHTS_WORKSPACE=1 OPINSIGHTS_WORKSPACE_ID=' + $logAnalyticsWorkplaceID + ' OPINSIGHTS_WORKSPACE_KEY=' + $logAnalyticsWorkplaceKey + ' AcceptEndUserLicenseAgreement=1"'
+            ProductId = "" # ProductId to the 64-bit version of the agent. The 64-bit version has different id.
+            DependsOn = "[xRemoteFile]logAnalyticsAgentPackage"
+        }
+
+        #Verifying that the agent service is running
+        xService logAnalyticsAgentService {
+            Name      = "HealthService"
+            Ensure    = "Present"
+            State     = "Running"
+            DependsOn = "[xPackage]logAnalyticsAgent"
+        }
+
+        #Logging the installation in the event log (Microsoft-Windows-Desired State Configuration/Analytic event log)
+        Log logAnalyticsAgentInstalled {
+            Message   = "Microsoft Monitoring Agent has been successfully installed."
+            DependsOn = "[xService]logAnalyticsAgentService"
+        }
+
+        #endregion
+
+        #region Microsoft Dependency agent
+
+        #Download installation file for Microsoft Dependency agent
+        xRemoteFile dependencyAgentPackage {
+            Uri             = "https://aka.ms/dependencyagentwindows" # Permalink to the agent package
+            DestinationPath = $dependencyAgentPackageLocalPath
+        }
+
+        #Installing Microsoft Dependency agent on a host
+        xPackage dependencyAgent {
+            Name                       = "Dependency Agent"
+            Ensure                     = "Present"
+            Path                       = $dependencyAgentPackageLocalPath
+            Arguments                  = '/S'
+            ProductId                  = ""
+            InstalledCheckRegKey       = "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\DependencyAgent"
+            InstalledCheckRegValueName = "DisplayName"
+            InstalledCheckRegValueData = "Dependency Agent"
+            DependsOn                  = "[xRemoteFile]dependencyAgentPackage", "[xPackage]logAnalyticsAgent"
+        }
+
+        #Verifying that the agent service is running
+        xService dependencyAgentService {
+            Name      = "MicrosoftDependencyAgent"
+            Ensure    = "Present"
+            State     = "Running"
+            DependsOn = "[xPackage]dependencyAgent"
+        }
+
+        #Logging the installation in the event log (Microsoft-Windows-Desired State Configuration/Analytic event log)
+        Log DependencyAgentInstalled {
+            Message   = "Dependency Agent has been successfully installed."
+            DependsOn = "[xService]dependencyAgentService"
+        }
+
+        #endregion
+    }
+}

--- a/Tests/artifacts/Tasks/armlogin.ps1
+++ b/Tests/artifacts/Tasks/armlogin.ps1
@@ -5,6 +5,6 @@ param(
     [pscredential]$Credential
 )
 Write-Verbose "Logging in to tenant $Tenant"
-Add-AzureRMAccount -ServicePrincipal -Tenant $Tenant -Credential $Credential
+Add-AzAccount -ServicePrincipal -Tenant $Tenant -Credential $Credential
 Write-Verbose "Selecting scubscription $SubscriptionID"
-Select-AzureRMSubscription -SubscriptionId $SubscriptionID
+Select-AzSubscription -SubscriptionId $SubscriptionID


### PR DESCRIPTION
Added new deployment types to deploy Azure Automation runbooks, DSC configurations and modules.
The deployment type for Azure Automation modules supports deployment from a public PS repository like PowerShell Gallery, from a private repository like Azure Artifacts private NuGet feed, and from a local source path. To support the deployment from a public or private PS repository, the 'SourceIsAbsolute = $true' option is used in deployment configurations. See, the deployment script help for the configuration snippets.

Any suggestions for improving the test cases are highly appreciated.