### PR TITLE
Add SkipAutomaticTags to PSGalleryModule.

### DIFF
--- a/PSDeploy/PSDeployScripts/PSGalleryModule.ps1
+++ b/PSDeploy/PSDeployScripts/PSGalleryModule.ps1
@@ -61,7 +61,6 @@ foreach($deploy in $Deployment) {
         if ($Credential) {
             $params['Credential']  =  $deploy.DeploymentOptions.Credential
         }
-        
 
         Publish-Module @params
     }

--- a/PSDeploy/PSDeployScripts/PSGalleryModule.ps1
+++ b/PSDeploy/PSDeployScripts/PSGalleryModule.ps1
@@ -8,6 +8,9 @@
 
     .PARAMETER Deployment
         Deployment to run
+     
+    .PARAMETER SkipAutomaticTags
+        Removes commands and resources from being included as tags. Skips automatically adding tags to a module.
 
     .PARAMETER ApiKey
         API Key used to authenticate to PowerShell repository.
@@ -49,12 +52,16 @@ foreach($deploy in $Deployment) {
             Repository = $target
             Verbose    = $VerbosePreference
         }
+        if ($SkipAutomaticTags) {
+            $params['SkipAutomaticTags'] = $deploy.DeploymentOptions.SkipAutomaticTags
+        }
         if ($ApiKey) {
             $params['NuGetApiKey']  =  $deploy.DeploymentOptions.ApiKey
         }
         if ($Credential) {
             $params['Credential']  =  $deploy.DeploymentOptions.Credential
         }
+        
 
         Publish-Module @params
     }

--- a/Tests/artifacts/DeploymentsPSGalleryModule.psdeploy.ps1
+++ b/Tests/artifacts/DeploymentsPSGalleryModule.psdeploy.ps1
@@ -5,6 +5,7 @@ Deploy TestModule {
         Tagged Testing
         WithOptions @{
             ApiKey = '0c3e374b-49a3-4b05-a597-fd45773a4fb6'
+            SkipAutomaticTags = $false
         }
     }
 }

--- a/Tests/artifacts/DeploymentsPSGalleryModule.psdeploy.ps1
+++ b/Tests/artifacts/DeploymentsPSGalleryModule.psdeploy.ps1
@@ -5,7 +5,7 @@ Deploy TestModule {
         Tagged Testing
         WithOptions @{
             ApiKey = '0c3e374b-49a3-4b05-a597-fd45773a4fb6'
-            SkipAutomaticTags = $false
+            SkipAutomaticTags = $true
         }
     }
 }


### PR DESCRIPTION
By default, Publish-Module adds tags for every given function in a module. The SkipAutomaticTags parameter allows the user to skip this.  

I am new to contributing to this project. I understand my change should allow for the SkipAutomaticTags parameter to be added to WithOptions, which will pass it to the PSGalleryModule script then Publish-Module.